### PR TITLE
turn on cached resolution in SBT.  See:

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -98,7 +98,8 @@ lazy val commonSettings = Seq(
   logLevel in assembly := Level.Info,
   resolvers            += Resolver.jcenterRepo,
   shellPrompt          := { state => "%s| %s> ".format(GitCommand.prompt.apply(state), version.value) },
-  coverageExcludedPackages := "<empty>;dagr\\.tasks.*;dagr\\.pipelines.*"
+  coverageExcludedPackages := "<empty>;dagr\\.tasks.*;dagr\\.pipelines.*",
+  updateOptions        := updateOptions.value.withCachedResolution(true)
 ) ++ Defaults.coreDefaultSettings
 
 ////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
- http://www.scala-sbt.org/0.13/docs/Cached-Resolution.html

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/fulcrumgenomics/dagr/2)

<!-- Reviewable:end -->
