### PR TITLE
Adding support for publishing to sonatype

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ scala:
 jdk:
 - oraclejdk8
 script:
-- sbt clean coverage test && sbt coverageAggregate 
+- sbt clean coverage test && sbt coverageAggregate
 - find $HOME/.sbt -name "*.lock" | xargs rm
 - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
 cache:
@@ -16,3 +16,8 @@ before_install:
 - pip install --user codecov
 after_success:
 - codecov
+- test "${TRAVIS_PULL_REQUEST}" = 'false' && test "${TRAVIS_JDK_VERSION}" = 'oraclejdk8' && sbt 'project respite-core' 'set credentials += Credentials("Sonatype Nexus Repository Manager", "oss.sonatype.org", System.getenv("SONATYPE_USER"), System.getenv("SONATYPE_PASS"))' publish
+env:
+  global:
+  - secure: lfzQekeDlZflKZGYg4Ueft5lLDHbSfvEUrGSJai5PI4WSsa9DwMxst8R4YV5PDt48nMBTlCzMJ+ZfkOHoBTrGpi02ezyU5EUAHYU+SCg2qDuMi2IcV8+leu7w3ao01xFCnFZoimWMU9SaFh5RBPGAM7fBifJs7gsqxNawtHlMS8tC/MBAaXfPZzGw1im3UZc/hreCR/R4p+FNWRw8GNPyTRcJRNFrPrSKkW0CoJss+RG9ZEX7WGPXqCS71NODEi7pE1NynkN9j8CVMFxavfAqW5TOxNU1dZdkxD8QEDcAIo479vG1uHE+4HrQk3Yl1ZzS2HMmNbfpU+8XwgCXhQtEreXUwaXZpALKqYEP4xqmUFTPAe2vfiQUqppsH7zuVpcP4B/xB5ovgOuPrgyOZwLfR9UfqS3oMRSj3BZ0qNZIL4eISS1jONzid7sGVLZiyHT2nXR2puWaYY6wNvgw2Rf97TyZkyYx/abbJQzhQy2ETl3UoTvqUBpYPWI5W0IJMJvzJsc6HS4+ukuknJqaXGFO5RBE1xm+fyV1zHFMz0mQQ+S9egmuJDyPCjyz+uYpNGFqG3wLhZZZhEdEerONMK744p2sTyARrsiq0prlWgH5XZydcYLQjfXTcUvYNoqaeMvaLaJsTj8k44p4RFIZjzVbkONehVjndAzYgjOEa6/iy4=
+  - secure: it4XCJjWKW2IjA28LHUJeRUsVANmnf1RiqUmAeGvu4aKD9/q2ypW5xIzIO1mIMJRQpyef/s6haPfFWVySn5hA30EM/1fvCIqy4rVIuE4OxxquKYdHUIQArEaFs6F0uYXOU7hgZiMbye1/nryX65/eJllCvCzTBSORYuIZw4WuMuZGQGCuBUY+AQJHjFGRjl52va4U/SS/M00bkQtVASJxIBsnaxHzgSMXEmsjmGOG5WFQqGdwfXIjYF7L21vOxe2VXSOjIQgKqJcx/15LGrmDdG9uLaQS0LFyis0rHUUQP9iiiOJv0Ax/TKXInaQ5+52N/xIYOvbSlkeOgR0bEnKlXVIRmIqB+D8UlidF9WYDi2wS1z8j7EOPynNxfSJB7jPeZtqbG4Yr7OmpIyW2ZGbjcJNT/CNHPDzQe9Z+AUYCJhSN1LDYd2YDl3X24pcGGA9Fo5uGDDWN/Gn0d+EllYw8ICaXBpXXrbs9k6CjUB/HFIWo7cwu783nJdAyN4RrIfYZ2Yo9CsAzl7urT43UW0R65OzUruFCNsOS5pmDOe5wXyqPe/5GRxWrIxbWl0Ls3LkNoJgGTlVVi0fwD2EG8mX5v33/GQLhppl1fWrOx5oChvBBMYhXOa+xhcdEkwynZuATsbdnHddIyHn8g9fQ44M0KOnZbWZYXo5Idmk6iWXCcc=

--- a/build.sbt
+++ b/build.sbt
@@ -2,20 +2,103 @@ import sbt._
 import sbt.Keys._
 import sbtassembly.AssemblyKeys.assembly
 import sbtassembly.MergeStrategy
-import sbtrelease.ReleasePlugin._
 import com.typesafe.sbt.SbtGit.GitCommand
 import scoverage.ScoverageSbtPlugin.ScoverageKeys._
+import sbtrelease._
+// we hide the existing definition for setReleaseVersion to replace it with our own
+import sbtrelease.ReleaseStateTransformations.{setReleaseVersion=>_,_}
 
-// for the aggregate (root) jar, override the name.  For the sub-projects, see the build.sbt in each project folder.
+////////////////////////////////////////////////////////////////////////////////////////////////
+// We have the following "settings" in this build.sbt:
+// - custom versioning with sbt-release and sbt-git
+// - custom JAR name for the root project
+// - settings to publish to Sonatype
+// - exclude the root, tasks, and pipelines project from code coverage
+// - scaladoc settings
+// - custom merge strategy for assembly
+////////////////////////////////////////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////////////////////////////////////////
+// Use sbt-release and sbt-git to add the git hash to the snapshots version numbers.
+//
+// see: http://blog.byjean.eu/2015/07/10/painless-release-with-sbt.html
+////////////////////////////////////////////////////////////////////////////////////////////////
+
+// git versioning settings
+git.useGitDescribe := true
+val VersionRegex = "v([0-9]+.[0-9]+.[0-9]+)-?(.*)?".r
+git.gitTagToVersionNumber := {
+  case VersionRegex(v,"") => Some(v)
+  case VersionRegex(v,"SNAPSHOT") => Some(s"$v-SNAPSHOT")
+  case VersionRegex(v,s) => Some(s"$v-$s-SNAPSHOT")
+  case _ => None
+}
+// Update the base version here
+git.baseVersion := "0.1.0"
+
+// redefine the steps to set the release and next development versions to avoid writing to the version file
+def setVersionOnly(selectVersion: Versions => String): ReleaseStep =  { st: State =>
+  val vs = st.get(ReleaseKeys.versions).getOrElse(sys.error("No versions are set! Was this release part executed before inquireVersions?"))
+  val selected = selectVersion(vs)
+
+  st.log.info("Setting version to '%s'." format selected)
+  val useGlobal =Project.extract(st).get(releaseUseGlobalVersion)
+  val versionStr = (if (useGlobal) globalVersionString else versionString) format selected
+
+  reapply(Seq(
+    if (useGlobal) version in ThisBuild := selected
+    else version := selected
+  ), st)
+}
+// make sure to bump to the next version upon release, not the current one
+lazy val setReleaseVersion: ReleaseStep = setVersionOnly(_._1)
+releaseVersion <<= releaseVersionBump( bumper=>{
+  ver => Version(ver)
+    .map(_.withoutQualifier)
+    .map(_.bump(bumper).string).getOrElse(versionFormatError)
+})
+
+// use a short hash
+git.formattedShaVersion := git.gitHeadCommit.value map { sha => s"v$sha" }
+
+// Release settings
+releaseVersionBump := sbtrelease.Version.Bump.Next
+releasePublishArtifactsAction := PgpKeys.publishSigned.value
+
+////////////////////////////////////////////////////////////////////////////////////////////////
+// For the aggregate (root) jar, override the name.  For the sub-projects,
+// see the build.sbt in each project folder.
+////////////////////////////////////////////////////////////////////////////////////////////////
 assemblyJarName in assembly := "dagr-" + version.value + ".jar"
 
-releaseSettings
+////////////////////////////////////////////////////////////////////////////////////////////////
+// Sonatype settings
+////////////////////////////////////////////////////////////////////////////////////////////////
+publishMavenStyle := true
+publishTo := {
+  val nexus = "https://oss.sonatype.org/"
+  if (isSnapshot.value)
+    Some("snapshots" at nexus + "content/repositories/snapshots")
+  else
+    Some("releases"  at nexus + "service/local/staging/deploy/maven2")
+}
+publishArtifact in Test := false
+pomIncludeRepository := { _ => false }
 
+////////////////////////////////////////////////////////////////////////////////////////////////
+// Coverage settings: only count coverage of dagr.sopt and dagr.core
+////////////////////////////////////////////////////////////////////////////////////////////////
 coverageExcludedPackages := "<empty>;dagr\\.tasks.*;dagr\\.pipelines.*;dagr\\.cmdline.*"
-
 val htmlReportsDirectory: String = "target/test-reports"
 
+////////////////////////////////////////////////////////////////////////////////////////////////
+// scaladoc options
+////////////////////////////////////////////////////////////////////////////////////////////////
+val docScalacOptions = Seq("-groups", "-implicits")
+
+////////////////////////////////////////////////////////////////////////////////////////////////
 // Common settings for all projects
+////////////////////////////////////////////////////////////////////////////////////////////////
 lazy val commonSettings = Seq(
   organization         := "com.fulcrumgenomics",
   organizationName     := "Fulcrum Genomics LLC",
@@ -23,6 +106,9 @@ lazy val commonSettings = Seq(
   startYear            := Some(2015),
   scalaVersion         := "2.11.7",
   scalacOptions        += "-target:jvm-1.8",
+  scalacOptions in (Compile, doc) ++= docScalacOptions,
+  scalacOptions in (Test, doc) ++= docScalacOptions,
+  autoAPIMappings := true,
   testOptions in Test  += Tests.Argument(TestFrameworks.ScalaTest, "-h", Option(System.getenv("TEST_HTML_REPORTS")).getOrElse(htmlReportsDirectory)),
   testOptions in Test  += Tests.Argument("-l", "LongRunningTest"), // ignores long running tests
   // uncomment for full stack traces
@@ -35,6 +121,9 @@ lazy val commonSettings = Seq(
   coverageExcludedPackages := "<empty>;dagr\\.tasks.*;dagr\\.pipelines.*"
 ) ++ Defaults.coreDefaultSettings
 
+////////////////////////////////////////////////////////////////////////////////////////////////
+// sopt project
+////////////////////////////////////////////////////////////////////////////////////////////////
 lazy val sopt = Project(id="dagr-sopt", base=file("sopt"))
   .settings(commonSettings: _*)
   .settings(description := "Scala command line option parser.")
@@ -44,7 +133,11 @@ lazy val sopt = Project(id="dagr-sopt", base=file("sopt"))
       "org.scalatest"      %%  "scalatest"       %  "2.2.4" % "test->*" excludeAll ExclusionRule(organization="org.junit", name="junit")
     )
   )
+  .enablePlugins(GitVersioning)
 
+////////////////////////////////////////////////////////////////////////////////////////////////
+// core project
+////////////////////////////////////////////////////////////////////////////////////////////////
 lazy val core = Project(id="dagr-core", base=file("core"))
   .settings(commonSettings: _*)
   .settings(description := "Core methods and classes to execute tasks in dagr.")
@@ -61,24 +154,38 @@ lazy val core = Project(id="dagr-core", base=file("core"))
     )
   )
   .dependsOn(sopt)
-
+  .enablePlugins(GitVersioning)
+////////////////////////////////////////////////////////////////////////////////////////////////
+// tasks project
+////////////////////////////////////////////////////////////////////////////////////////////////
 lazy val tasks = Project(id="dagr-tasks", base=file("tasks"))
   .settings(description := "A set of example dagr tasks.")
   .settings(commonSettings: _*)
   .dependsOn(core)
+  .enablePlugins(GitVersioning)
 
+////////////////////////////////////////////////////////////////////////////////////////////////
+// pipelines project
+////////////////////////////////////////////////////////////////////////////////////////////////
 lazy val pipelines = Project(id="dagr-pipelines", base=file("pipelines"))
   .settings(description := "A set of example dagr pipelines.")
   .settings(commonSettings: _*)
   .dependsOn(tasks, core)
+  .enablePlugins(GitVersioning)
 
+////////////////////////////////////////////////////////////////////////////////////////////////
+// root (dagr) project
+////////////////////////////////////////////////////////////////////////////////////////////////
 lazy val root = Project(id="dagr", base=file("."))
   .settings(commonSettings: _*)
   .settings(description := "A tool to execute tasks in directed acyclic graphs.")
   .aggregate(sopt, core, tasks, pipelines)
   .dependsOn(sopt, core, tasks, pipelines)
+  .enablePlugins(GitVersioning)
 
-
+////////////////////////////////////////////////////////////////////////////////////////////////
+// Merge strategy for assembly
+////////////////////////////////////////////////////////////////////////////////////////////////
 val customMergeStrategy: String => MergeStrategy = {
   case x if Assembly.isConfigFile(x) =>
     MergeStrategy.concat
@@ -90,15 +197,15 @@ val customMergeStrategy: String => MergeStrategy = {
     } match {
       case ("manifest.mf" :: Nil) | ("index.list" :: Nil) | ("dependencies" :: Nil) =>
         MergeStrategy.discard
-      case ps@(x :: xs) if ps.last.endsWith(".sf") || ps.last.endsWith(".dsa") =>
+      case ps@(x :: xt) if ps.last.endsWith(".sf") || ps.last.endsWith(".dsa") =>
         MergeStrategy.discard
-      case "plexus" :: xs =>
+      case "plexus" :: xt =>
         MergeStrategy.discard
-      case "spring.tooling" :: xs =>
+      case "spring.tooling" :: xt =>
         MergeStrategy.discard
-      case "com.google.guava" :: xs =>
+      case "com.google.guava" :: xt =>
         MergeStrategy.discard
-      case "services" :: xs =>
+      case "services" :: xt =>
         MergeStrategy.filterDistinctLines
       case ("spring.schemas" :: Nil) | ("spring.handlers" :: Nil) =>
         MergeStrategy.filterDistinctLines
@@ -110,5 +217,4 @@ val customMergeStrategy: String => MergeStrategy = {
     MergeStrategy.first
   case _ => MergeStrategy.deduplicate
 }
-
 assemblyMergeStrategy in assembly := customMergeStrategy

--- a/core/src/main/scala/dagr/core/tasksystem/Task.scala
+++ b/core/src/main/scala/dagr/core/tasksystem/Task.scala
@@ -86,16 +86,16 @@ object Task {
   }
 
   /** Indicates if a given set of tasks that are strongly connected components contains a cycle. This is the
-    * case if the set size is greater than one, or the task is depends on itself.  See [[findStronglyConnectedComponents()]]
+    * case if the set size is greater than one, or the task is depends on itself.  See [[Task.findStronglyConnectedComponents()]]
     * for how to retrieve strongly connected components from a task.
     *
     * @param component the strongly connected component.
     * @return true if the component contains a cycle, false otherwise.
     */
   def isComponentACycle(component: Set[Task]): Boolean = {
-    if (1 < component.size) return true
-    else if (component.head.getTasksDependedOn.toSet.contains(component.head)) return true
-    else if (component.head.getTasksDependingOnThisTask.toSet.contains(component.head)) return true
+    if (1 < component.size) true
+    else if (component.head.getTasksDependedOn.toSet.contains(component.head)) true
+    else if (component.head.getTasksDependingOnThisTask.toSet.contains(component.head)) true
     else false
   }
 

--- a/core/src/main/scala/dagr/core/tasksystem/UnitTask.scala
+++ b/core/src/main/scala/dagr/core/tasksystem/UnitTask.scala
@@ -23,19 +23,15 @@
  */
 package dagr.core.tasksystem
 
-import dagr.core.execsystem
-import dagr.core.execsystem.Resource._
 import dagr.core.execsystem.{ResourceSet, Scheduler}
 import dagr.core.util.LazyLogging
-
-import scala.collection.mutable.ListBuffer
 
 /** A task that should be directly executed or scheduled.
  *
  * A few things about unit tasks:
  * - a task can depend on data from tasks on which it is dependent.  See [[Callbacks]]
  * - a task extending this class should return only one task in its getTasks method.  See [[Task.getTasks]]
- * - a task can perform any final logic dependent on the resources with which it is scheduled.  See [[Scheduler.schedule]].
+ * - a task can perform any final logic dependent on the resources with which it is scheduled.  See [[Scheduler!.schedule*]].
   *
  * When a unit task gets scheduled, the [[dagr.core.execsystem.Scheduler.schedule]] method will be called to allow any final
  * logic based on the resources this task was scheduled with.  This is in addition to the steps listed in [[Task]].

--- a/core/src/main/scala/dagr/core/tasksystem/ValidationException.scala
+++ b/core/src/main/scala/dagr/core/tasksystem/ValidationException.scala
@@ -31,6 +31,6 @@ case class ValidationException(val messages: List[String]) extends RuntimeExcept
   /** Alternate constructor that takes var arg Strings and turns them into a List. */
   def this(messages: String*) = this(messages.toList)
 
-  /** Alternate constructor that takes any [[Iterable]] of Strings and turns them into a List. */
+  /** Alternate constructor that takes any [[scala.Iterable]] of Strings and turns them into a List. */
   def this(messages: Iterable[String]) = this(messages.toList)
 }

--- a/pipelines/src/main/scala/dagr/pipelines/CreateUnmappedBamFromFastqPipeline.scala
+++ b/pipelines/src/main/scala/dagr/pipelines/CreateUnmappedBamFromFastqPipeline.scala
@@ -35,13 +35,16 @@ import htsjdk.samtools.SAMFileHeader.SortOrder
 import scala.collection.mutable.ListBuffer
 
 object CreateUnmappedBamFromFastqPipeline {
-  final val NAME = "Create Unmapped Bam From Fastq Pipeline"
+  @inline
+  final val SUMMARY = """Create Unmapped Bam From Fastq Pipeline.  Runs:
+ - FastqToSam -> MarkIlluminaAdapters -> Unmapped BAM"""
+  @inline
+  final val ONE_LINE_SUMMARY = "Create Unmapped Bam From Fastq Pipeline."
 }
 
 @CLP(
-  summary = CreateUnmappedBamFromFastqPipeline.NAME + ".  Runs:"
-    + "\n\t - FastqToSam -> MarkIlluminaAdapters -> Unmapped BAM",
-  oneLineSummary = CreateUnmappedBamFromFastqPipeline.NAME + ".",
+  summary = CreateUnmappedBamFromFastqPipeline.SUMMARY,
+  oneLineSummary = CreateUnmappedBamFromFastqPipeline.ONE_LINE_SUMMARY,
   pipelineGroup = classOf[Pipelines])
 class CreateUnmappedBamFromFastqPipeline(
   @Arg(doc="Input fastq file (optionally gzipped) for read 1.")                   val fastq1: List[PathToFastq],
@@ -56,7 +59,7 @@ class CreateUnmappedBamFromFastqPipeline(
   @Arg(doc="Path to the unmapped BAM. Use the output prefix if none is given. ")  var unmappedBam: Option[PathToBam] = None
 ) extends Pipeline(Some(output)) {
 
-  name = CreateUnmappedBamFromFastqPipeline.NAME
+  name = CreateUnmappedBamFromFastqPipeline.ONE_LINE_SUMMARY.dropRight(1)
 
   // Validation logic as constructor code
   var errors: ListBuffer[String] = new ListBuffer[String]()

--- a/pipelines/src/main/scala/dagr/pipelines/DNAResequencingFromFastqPipeline.scala
+++ b/pipelines/src/main/scala/dagr/pipelines/DNAResequencingFromFastqPipeline.scala
@@ -34,17 +34,19 @@ import dagr.tasks._
 import scala.collection.mutable.ListBuffer
 
 object DnaResequencingFromFastqPipeline {
-  final val NAME = "Dna Resequencing from Fastq Pipeline"
+  @inline
+  final val SUMMARY = """Dna Resequencing from Fastq Pipeline.\n\t - FastqToSam -> MarkIlluminaAdapters -> Unmapped BAM
+ - Unmapped BAM -> SamToFastq -> Bwa Mem -> MergeBamAlignment -> MarkDuplicates -> Mapped BAM
+ - Mapped BAM -> {CollectMultipleMetrics, EstimateLibraryComplexity, ValidateSamFile}
+ - Mapped BAM -> {CalculateHsMetrics, CollectTargetedPcrMetrics} if targets are given
+ - Mapped BAM -> {CollectWgsMetrics, CollectGcBiasMetrics} if targets are not given"""
+  @inline
+  final val ONE_LINE_SUMMARY = "Dna Resequencing from Fastq Pipeline."
 }
 
 @CLP(
-  summary = DnaResequencingFromFastqPipeline.NAME + ".  Runs:"
-    + "\n\t - FastqToSam -> MarkIlluminaAdapters -> Unmapped BAM"
-    + "\n\t - Unmapped BAM -> SamToFastq -> Bwa Mem -> MergeBamAlignment -> MarkDuplicates -> Mapped BAM"
-    + "\n\t - Mapped BAM -> {CollectMultipleMetrics, EstimateLibraryComplexity, ValidateSamFile}"
-    + "\n\t - Mapped BAM -> {CalculateHsMetrics, CollectTargetedPcrMetrics} if targets are given"
-    + "\n\t - Mapped BAM -> {CollectWgsMetrics, CollectGcBiasMetrics} if targets are not given",
-  oneLineSummary = DnaResequencingFromFastqPipeline.NAME + ".",
+  summary = DnaResequencingFromFastqPipeline.SUMMARY,
+  oneLineSummary = DnaResequencingFromFastqPipeline.ONE_LINE_SUMMARY,
   pipelineGroup = classOf[Pipelines])
 class DnaResequencingFromFastqPipeline(
   @Arg(doc="Input fastq file (optionally gzipped) for read 1.")    val fastq1: List[PathToFastq],
@@ -61,7 +63,7 @@ class DnaResequencingFromFastqPipeline(
   @Arg(flag="o", doc="The output directory to which files are written.")  val output: DirPath,
   @Arg(doc="The basename for all output files. Uses library if omitted.") val basename: Option[FilenamePrefix]
 ) extends Pipeline(outputDirectory = Some(output)) {
-  name = DnaResequencingFromFastqPipeline.NAME
+  name = DnaResequencingFromFastqPipeline.ONE_LINE_SUMMARY.dropRight(2)
 
   // Validation logic as constructor code
   var errors: ListBuffer[String] = new ListBuffer[String]()

--- a/pipelines/src/main/scala/dagr/pipelines/DNAResequencingFromUnmappedBamPipeline.scala
+++ b/pipelines/src/main/scala/dagr/pipelines/DNAResequencingFromUnmappedBamPipeline.scala
@@ -36,17 +36,18 @@ import dagr.tasks.picard._
 import scala.collection.mutable.ListBuffer
 
 object DnaResequencingFromUnmappedBamPipeline {
-  final val NAME =  "Dna Resequencing From Unmapped BAM Pipeline"
+  final val SUMMARY =  """Dna Resequencing From Unmapped BAM Pipeline.  Runs:
+\t - Unmapped BAM -> EstimateLibraryComplexity"
+\t - Unmapped BAM -> SamToFastq -> Bwa Mem -> MergeBamAlignment -> MarkDuplicates -> Mapped BAM
+\t - Mapped BAM -> {CollectMultipleMetrics, EstimateLibraryComplexity, ValidateSamFile}
+\t - Mapped BAM -> {CalculateHsMetrics, CollectTargetedPcrMetrics} if targets are given
+\t - Mapped BAM -> {CollectWgsMetrics, CollectGcBiasMetrics} if targets are not given"""
+  final val ONE_LINE_SUMMARY =  "Dna Resequencing From Unmapped BAM Pipeline"
 }
 
 @CLP(
-  summary = DnaResequencingFromUnmappedBamPipeline.NAME + ".  Runs:"
-    + "\n\t - Unmapped BAM -> EstimateLibraryComplexity"
-    + "\n\t - Unmapped BAM -> SamToFastq -> Bwa Mem -> MergeBamAlignment -> MarkDuplicates -> Mapped BAM"
-    + "\n\t - Mapped BAM -> {CollectMultipleMetrics, EstimateLibraryComplexity, ValidateSamFile}"
-    + "\n\t - Mapped BAM -> {CalculateHsMetrics, CollectTargetedPcrMetrics} if targets are given"
-    + "\n\t - Mapped BAM -> {CollectWgsMetrics, CollectGcBiasMetrics} if targets are not given",
-  oneLineSummary = DnaResequencingFromUnmappedBamPipeline.NAME + ".",
+  summary = DnaResequencingFromUnmappedBamPipeline.SUMMARY,
+  oneLineSummary = DnaResequencingFromUnmappedBamPipeline.ONE_LINE_SUMMARY,
   pipelineGroup = classOf[Pipelines])
 class DnaResequencingFromUnmappedBamPipeline(
   @Arg(doc="Path to the unmapped BAM.")                            val unmappedBam: PathToBam,
@@ -59,7 +60,7 @@ class DnaResequencingFromUnmappedBamPipeline(
   @Arg(doc="The filename prefix for output files.")                val basename: FilenamePrefix
 ) extends Pipeline(Some(output)) {
 
-  name = DnaResequencingFromUnmappedBamPipeline.NAME
+  name = DnaResequencingFromUnmappedBamPipeline.ONE_LINE_SUMMARY.dropRight(1)
 
   override def build(): Unit = {
     val prefix = output.resolve(basename)

--- a/pipelines/src/main/scala/dagr/pipelines/GermlineVariantCallingPipeline.scala
+++ b/pipelines/src/main/scala/dagr/pipelines/GermlineVariantCallingPipeline.scala
@@ -38,10 +38,10 @@ import dagr.tasks.vc.{FilterFreeBayesCalls, FreeBayesGermline}
   *
   */
 @CLP(
-  summary = "Calls germline variants in a single sample and then hard filters them.\n" +
-            "For GATK, calls are made using the GATK's HaplotypeCaller and filtering with\n" +
-            "Picard's FilterVcf.  For FreeBayes, calls are made using bcbio's best practices.\n" +
-            "Optionally, variants are assessed with Picard's GenotypeConcordance tool.",
+  summary = """Calls germline variants in a single sample and then hard filters them.
+For GATK, calls are made using the GATK's HaplotypeCaller and filtering with
+Picard's FilterVcf.  For FreeBayes, calls are made using bcbio's best practices.
+Optionally, variants are assessed with Picard's GenotypeConcordance tool.""",
   oneLineSummary = "Calls and filters germline variants."
 )
 class GermlineVariantCallingPipeline(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,8 +2,12 @@ resolvers += Resolver.url("fix-sbt-plugin-releases", url("http://dl.bintray.com/
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.3")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.1")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.1")
+
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
+
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")

--- a/sonatype.sbt
+++ b/sonatype.sbt
@@ -1,0 +1,27 @@
+sonatypeProfileName := "com.fulcrumgenomics"
+
+pomExtra in Global := {
+  <url>http://github.com/fulcrumgenomics/dagr</url>
+    <licenses>
+      <license>
+        <name>MIT License</name>
+        <url>http://www.opensource.org/licenses/mit-license.html</url>
+      </license>
+    </licenses>
+    <scm>
+      <url>git@github.com:fulcrumgenomics/dagr</url>
+      <connection>scm:git:git@github.com:fulcrumgenomics/dagr.git</connection>
+    </scm>
+    <developers>
+      <developer>
+        <id>nh13</id>
+        <name>Nils Homer</name>
+        <url>http://github.com/nh13</url>
+      </developer>
+      <developer>
+        <id>tfenne</id>
+        <name>Tim Fennell</name>
+        <url>http://github.com/tfenne</url>
+      </developer>
+    </developers>
+}

--- a/tasks/src/main/scala/dagr/tasks/picard/PicardTask.scala
+++ b/tasks/src/main/scala/dagr/tasks/picard/PicardTask.scala
@@ -62,7 +62,7 @@ abstract class PicardTask(var jvmArgs: List[String] = Nil,
   extends ProcessTask with JarTask with FixedResources with Configuration {
   requires(Cores(1), Memory("4G"))
 
-  /** Looks up the first super class that is does not have "$anon$" in its name. */
+  /** Looks up the first super class that is does not have "\$anon\$" in its name. */
   def commandName : String = {
     var clazz : Class[_] = getClass
     while (clazz != null && clazz.getName.contains("$anon$")) clazz = clazz.getSuperclass


### PR DESCRIPTION
@tfenne preview of publishing artifacts to sonatype.  Once this is merged, we can publish artifacts with:

```
publishSigned
sonatypeRelease
```

The latter commmand (`sonatypeRelease) does the following:
- `sonatypeClose`
- `sonatypePromote`

Links:
- [Link to the "Using Sonatype with SBT" tutorial](http://www.scala-sbt.org/0.13/docs/Using-Sonatype.html)
- [Link to the sbt-pgp plugin](http://www.scala-sbt.org/sbt-pgp/)
- [Link to the sbt-sonatype plugin](https://github.com/xerial/sbt-sonatype)
- [Link to the Sonatype JIRA Issue](https://issues.sonatype.org/browse/OSSRH-20388)
