### PR TITLE
reverting back to the codecov badge from sheilds.io, since the latter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/fulcrumgenomics/dagr.svg?branch=master)](https://travis-ci.org/fulcrumgenomics/dagr)
-[![Coverage Status](https://img.shields.io/codecov/c/github/fulcrumgenomics/dagr/master.svg)](https://codecov.io/github/fulcrumgenomics/dagr?branch=master)
+[![Coverage Status](https://codecov.io/github/fulcrumgenomics/dagr/coverage.svg?branch=master)](https://codecov.io/github/fulcrumgenomics/dagr?branch=master)
 [![Code Review](https://api.codacy.com/project/badge/grade/52e1d786d9784c7192fae2f8e853fa34)](https://www.codacy.com/app/contact_32/dagr)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.fulcrumgenomics/dagr/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.fulcrumgenomics/dagr)
 [![Dependency Status](https://www.versioneye.com/user/projects/56b2d2d593b95a003c714340/badge.svg?style=round)](https://www.versioneye.com/user/projects/56b2d2d593b95a003c714340#dialog_dependency_badge)


### PR DESCRIPTION
isn't displaying correctly
