### PR TITLE
turning off the resubmit functionality until we need it; it causes

### DIFF
--- a/core/src/main/scala/dagr/core/execsystem/TaskManager.scala
+++ b/core/src/main/scala/dagr/core/execsystem/TaskManager.scala
@@ -293,6 +293,8 @@ class TaskManager(taskManagerResources: TaskManagerResources = TaskManagerDefaul
    * @param task the task to resubmit.
    * @return true if the task was successfully resubmitted, false otherwise.
    */
+  // This method fails occasionally, so there likely is a race condition.  Turning it off until `resubmit` is used.
+  /*
   override def resubmitTask(task: Task): Boolean = {
     taskIdFor(task) match {
       case Some(taskId) =>
@@ -315,6 +317,7 @@ class TaskManager(taskManagerResources: TaskManagerResources = TaskManagerDefaul
         false
     }
   }
+  */
 
   /** Compares two timestamp options.  If either option is empty, zero is returned. */
   private def compareOptionalTimestamps(left: Option[Timestamp], right: Option[Timestamp]): Int = (left, right) match {

--- a/core/src/main/scala/dagr/core/execsystem/TaskManagerState.scala
+++ b/core/src/main/scala/dagr/core/execsystem/TaskManagerState.scala
@@ -371,7 +371,8 @@ trait TaskManagerState extends LazyLogging {
     * @param task the task to resubmit.
     * @return true if the task was successfully resubmitted, false otherwise.
     */
-  def resubmitTask(task: Task): Boolean
+  // Turning it off until `resubmit` is used.
+  //def resubmitTask(task: Task): Boolean
 
   /** Checks if we have failed tasks.
    *

--- a/core/src/test/scala/dagr/core/execsystem/TaskManagerTest.scala
+++ b/core/src/test/scala/dagr/core/execsystem/TaskManagerTest.scala
@@ -263,8 +263,9 @@ class TaskManagerTest extends UnitSpec with PrivateMethodTester with OptionValue
     }
     else {
       // resubmit...
-      logger.debug("*** RESUBMIT TASK ***")
-      taskManager.resubmitTask(original) shouldBe true
+      throw new IllegalStateException("Resubmission has been removed")
+      //logger.debug("*** RESUBMIT TASK ***")
+      //taskManager.resubmitTask(original) shouldBe true
     }
 
     // run and check again
@@ -297,12 +298,15 @@ class TaskManagerTest extends UnitSpec with PrivateMethodTester with OptionValue
     }
   }
 
+  // This test fails occasionally, so there likely is a race condition.  Turning it off until `resubmit` is used.
+  /*
   it should "resubmit a task that failed and re-run to completion" in {
     val original: UnitTask = new RetryMutatorTask
     val taskManager: TaskManager = getDefaultTaskManager
 
     doTryAgain(original = original, replacement = null, replaceTask = false, taskManager = taskManager)
   }
+  */
 
   it should "return false when replacing an un-tracked task" in {
     val task: UnitTask = new ShellCommand("exit 0") withName "Blah"
@@ -310,11 +314,14 @@ class TaskManagerTest extends UnitSpec with PrivateMethodTester with OptionValue
     taskManager.replaceTask(task, null) should be(false)
   }
 
+  // This test fails occasionally, so there likely is a race condition.  Turning it off until `resubmit` is used.
+  /*
   it should "return false when resubmitting an un-tracked task" in {
     val task: UnitTask = new ShellCommand("exit 0") withName "Blah"
     val taskManager: TaskManager = getDefaultTaskManager
     taskManager.resubmitTask(task) should be(false)
   }
+  */
 
   // ******************************************
   // onComplete success and failure


### PR DESCRIPTION
occasional failed tests
