### PR TITLE
Implementation of argparse style argument files.

### DIFF
--- a/core/src/main/scala/dagr/core/cmdline/parsing/SpecialArgumentsCollection.scala
+++ b/core/src/main/scala/dagr/core/cmdline/parsing/SpecialArgumentsCollection.scala
@@ -50,6 +50,4 @@ private[parsing] final case class SpecialArgumentsCollection(
   var help: Boolean = false,
   @Arg(name = "version", doc = "Display the version number for this tool.", special = true)
   var version: Boolean = false
-  //@Arg(name = "arguments-file", doc = "Read one or more arguments files and add them to the command line.", special = true, minElements=0)
-  //var argumentsFile: List[Path] = Nil
 )

--- a/core/src/test/scala/dagr/core/cmdline/parsing/CommandLineParserTest.scala
+++ b/core/src/test/scala/dagr/core/cmdline/parsing/CommandLineParserTest.scala
@@ -499,31 +499,6 @@ class CommandLineParserTest extends UnitSpec with OptionValues {
     an[IllegalStateException] should be thrownBy parser(classOf[NoArgAnnotationWithoutDefaults]).argumentLookup
   }
 
-  "CommandLineParser.parseArgumentsFile" should "return no arguments with no lines" in {
-    CommandLineParser.parseArgumentsFile(Nil) shouldBe 'empty
-  }
-
-  it should "return no arguments with only comments" in {
-    val lines: List[String] = List[String]("# nothing", "# here")
-    CommandLineParser.parseArgumentsFile(lines) shouldBe 'empty
-  }
-
-  it should "return a single flag argument" in {
-    CommandLineParser.parseArgumentsFile(List[String]("-c")) shouldBe List("-c")
-    CommandLineParser.parseArgumentsFile(List[String]("--flag")) shouldBe List("--flag")
-  }
-
-  it should "return a single argument with a required value" in {
-    CommandLineParser.parseArgumentsFile(List[String]("-c val")) shouldBe List("-c", "val")
-    CommandLineParser.parseArgumentsFile(List[String]("--arg val")) shouldBe List("--arg", "val")
-  }
-
-  it should "return a two arguments with a required values" in {
-    CommandLineParser.parseArgumentsFile(List[String]("-c val -d val")) shouldBe List("-c", "val", "-d", "val")
-    CommandLineParser.parseArgumentsFile(List[String]("--arg val --barg val")) shouldBe List("--arg", "val", "--barg", "val")
-    CommandLineParser.parseArgumentsFile(List[String]("--aab s --b -c -d wer we -c")) shouldBe List("--aab", "s", "--b", "-c", "-d", "wer we", "-c")
-  }
-
   "CommandLineParser.usage" should "print out no arguments when no arguments are present" in {
     val usage = parser(classOf[NoArguments]).usage(printCommon = false, withPreamble = false, withSpecial = false)
     usage.indexOf(RequiredArguments) should be < 0
@@ -712,91 +687,6 @@ class CommandLineParserTest extends UnitSpec with OptionValues {
     errorMessageBuilder.isEmpty shouldBe false
     errorMessageBuilder.toString().indexOf("verbosity") should be > 0
   }
-
-  /*
-  private def writeTempArgumentsFile(lines: List[String]): Path = {
-    val tmpDir: Path = Files.createTempDirectory("argumentFile")
-    val tmpFile: Path = Files.createTempFile(tmpDir, "dagr", ".arguments")
-    val writer = new PrintWriter(tmpFile.toFile)
-    lines.foreach(writer.println)
-    writer.close()
-    tmpFile.toFile.deleteOnExit()
-    tmpDir.toFile.deleteOnExit()
-    tmpFile
-  }
-
-  it should "accept arguments from a file" in {
-    // write a temp file
-    val tmpFile = writeTempArgumentsFile(List("--string-set Foo\n Bar"))
-    // now try to parse and check the return
-    val usageBuilder: StringBuilder = new StringBuilder
-    val errorMessageBuilder: StringBuilder = new StringBuilder
-    val args = Array[String](
-      "--arguments-file", tmpFile.toString,
-      "--int-set", "1", "2",
-      "--int-arg", "1",
-      "--string-list", "Foo", "Bar"
-    )
-    val p = parser(classOf[GeneralTestingTask])
-    p.parse(usageBuilder = usageBuilder, errorMessageBuilder = errorMessageBuilder, args = args) shouldBe true
-    val task = p.instance.get    
-    task.stringList should have size 2
-    task.stringList shouldBe List[String]("Foo", "Bar")
-    task.stringSet should have size 2
-    task.stringSet shouldBe Set[String]("Foo", "Bar")
-    task.intSet should have size 2
-    task.intSet shouldBe Set[Int](1, 2)
-    task.intArg shouldBe 1
-    task.flag shouldBe false
-    (task.enumArg == LogLevel.Debug) shouldBe true
-  }
-
-  it should "accept arguments from multiple argument files" in {
-    // write top two temp files
-    val tmpFileOne = writeTempArgumentsFile(List("--string-set Foo\n Bar"))
-    val tmpFileTwo = writeTempArgumentsFile(List("--int-set 1\n 2"))
-    // now try to parse and check the return
-    val usageBuilder: StringBuilder = new StringBuilder
-    val errorMessageBuilder: StringBuilder = new StringBuilder
-    val args = Array[String](
-      "--arguments-file", tmpFileOne.toString,
-      "--arguments-file", tmpFileTwo.toString,
-      "--int-arg", "1",
-      "--string-list", "Foo", "Bar"
-    )
-    val p = parser(classOf[GeneralTestingTask])
-    p.parse(usageBuilder = usageBuilder, errorMessageBuilder = errorMessageBuilder, args = args) shouldBe true
-    val task = p.instance.get    
-    task.stringList should have size 2
-    task.stringList shouldBe List[String]("Foo", "Bar")
-    task.stringSet should have size 2
-    task.stringSet shouldBe Set[String]("Foo", "Bar")
-    task.intSet should have size 2
-    task.intSet shouldBe Set[Int](1, 2)
-    task.intArg shouldBe 1
-    task.flag shouldBe false
-    (task.enumArg == LogLevel.Debug) shouldBe true
-  }
-
-  it should "fail when an argument from an argument file is the same as from the command line" in {
-    // write a temp file
-    val tmpFile = writeTempArgumentsFile(List("--int-arg 1"))
-    // now try to parse and check the return
-    val usageBuilder: StringBuilder = new StringBuilder
-    val errorMessageBuilder: StringBuilder = new StringBuilder
-    val args = Array[String](
-      "--string-set", "Foo", "Bar",
-      "--arguments-file", tmpFile.toString,
-      "--int-set", "1", "2",
-      "--int-arg", "1",
-      "--string-list", "Foo", "Bar"
-    )
-    val p = parser(classOf[GeneralTestingTask])
-    p.parse(usageBuilder = usageBuilder, errorMessageBuilder = errorMessageBuilder, args = args) shouldBe false
-    errorMessageBuilder.nonEmpty shouldBe true
-    errorMessageBuilder.toString.indexOf(classOf[OptionSpecifiedMultipleTimesException].getSimpleName) should be > 0
-  }
-  */
 
   it should "accept mutex arguments" in {
     val errorMessageBuilder: StringBuilder = new StringBuilder

--- a/sopt/src/main/scala/dagr/sopt/OptionParser.scala
+++ b/sopt/src/main/scala/dagr/sopt/OptionParser.scala
@@ -37,16 +37,18 @@ import scala.util.{Failure, Success, Try}
   * similar methods.
   *
   * See the README.md for more information on valid arguments to [[OptionParser]]. */
-class OptionParser extends OptionLookup with Traversable[(OptionName, List[OptionValue])] {
-
+class OptionParser(val argFilePrefix: Option[String] = None) extends OptionLookup with Traversable[(OptionName, List[OptionValue])] {
   private var remainingArgs: Traversable[String] = Nil
 
   /** returns any remaining args that were not parsed in the previous call to `parse`. */
   def remaining: Traversable[String] = remainingArgs
 
   /** Parse the given args. If an error was found, the first error is returned */
-  def parse(args: String*): Try[this.type] = {
-    val argTokenizer = new ArgTokenizer(args:_*)
+  def parse(args: String*): Try[this.type] = parse(args.toList)
+
+  /** Parse the given args. If an error was found, the first error is returned */
+  def parse(args: List[String]) : Try[this.type] = {
+    val argTokenizer = new ArgTokenizer(args, argFilePrefix=argFilePrefix)
     val argTokenCollator = new ArgTokenCollator(argTokenizer)
 
     argTokenCollator.foreach {
@@ -59,7 +61,6 @@ class OptionParser extends OptionLookup with Traversable[(OptionName, List[Optio
     }
 
     remainingArgs = argTokenizer.takeRemaining
-
     Success(this)
   }
 


### PR DESCRIPTION
@nh13 I decided one commented out feature was enough, so did something about the argument file parsing.  This mimics how python's argparse does it, which I really like.  Makes it super-simple to have arguments full of spaces and special characters.

I'm open to suggestions (or PRs!) for improvement.  I'm not totally happy with the implementation of `takeNextToken` in `ArgTokenizer` but with the mix of `Try`s and `Option`s, I couldn't make it work with just maps and flatmaps.
