### PR TITLE
Refactor EitherTask to use call-by-name instead of var.

### DIFF
--- a/core/src/test/scala/dagr/core/tasksystem/TaskTest.scala
+++ b/core/src/test/scala/dagr/core/tasksystem/TaskTest.scala
@@ -190,22 +190,26 @@ class TaskTest extends UnitSpec with LazyLogging {
 
   /** Tests the EitherTask class */
   {
-    it should "be able to modify the flag of an EitherTask and get the correct task" in {
-      val leftTask: NoOpTask = new NoOpTask withName "leftTask"
-      val rightTask: NoOpTask = new NoOpTask withName "rightTask"
-      val eitherTask = new EitherTask(leftTask, rightTask, EitherTaskFlag.LEFT)
-      eitherTask.getTasks.head should be(leftTask)
-      eitherTask.flag = EitherTaskFlag.RIGHT
-      eitherTask.getTasks.head should be(rightTask)
+    "EitherTask" should "be return the correct ask as the choice changes over time" in {
+      val left  = new NoOpTask withName "leftTask"
+      val right = new NoOpInJvmTask("rightTask")
+
+      var choice : EitherTask.Choice = EitherTask.Left
+      val eitherTask = EitherTask(left, right, choice)
+      eitherTask.getTasks.head shouldBe left
+
+      choice = EitherTask.Right
+      eitherTask.getTasks.head shouldBe right
     }
 
-    "EitherTask" should "run the left or task depending on the flag with EitherTask" in {
-      val leftTask: NoOpTask = new NoOpTask withName "leftTask"
-      val rightTask: NoOpTask = new NoOpTask withName "rightTask"
-      new EitherTask(leftTask, rightTask, EitherTaskFlag.LEFT).getTasks.head should be(leftTask)
-      new EitherTask(leftTask, rightTask, EitherTaskFlag.RIGHT).getTasks.head should be(rightTask)
-      EitherTask(leftTask, rightTask, doLeft=true).getTasks.head should be(leftTask)
-      EitherTask(leftTask, rightTask, doLeft=false).getTasks.head should be(rightTask)
+    it should "run the left or right task depending on the flag with EitherTask" in {
+      val left  = new NoOpTask withName "leftTask"
+      val right = new NoOpInJvmTask("rightTask")
+      EitherTask(left, right, EitherTask.Left).getTasks.head should be(left)
+      EitherTask(left, right, EitherTask.Right).getTasks.head should be(right)
+
+      EitherTask.of(left, right, goLeft=true).getTasks.head should be(left)
+      EitherTask.of(left, right, goLeft=false).getTasks.head should be(right)
     }
   }
 


### PR DESCRIPTION
There's quite a lot going on in this relatively small commit:
1. Refactor so that choice is no longer a var, but is instead a call-by-name parameter that gets wrapped into a function that is evalulated when the choice needs to be made. This removes the need for a callback/linker to use EitherTask.
2. Removed the Enumeration in favor of a sealed trait and case objects as I find their usage to be nicer.
3. Made the constructor private so that EitherTask.apply() is the only way to make an EitherTask. This is to make the API cleaner since call-by-name parameters cannot be vals, so the companion wraps the call-by-name into a function that is passed to the contructor val.
4. I had to make the Boolean version have a different name (EitherTask.of()) because apply(Task,Task,=>Choice) and apply(Task,Task,=>Boolean) have the same type after erasure and the compiler won't allow that :(
