### PR TITLE
updating the freebayes to work with pipes, added a few datatypes, and a

### DIFF
--- a/core/src/main/scala/dagr/core/tasksystem/Pipe.scala
+++ b/core/src/main/scala/dagr/core/tasksystem/Pipe.scala
@@ -91,9 +91,9 @@ trait PipeOut[Out] extends Pipe[Void,Out]
 ///////////////////////////////////////////////////////////////////////////////
 object Pipes {
   /** The string that is sandwiched between commands to form pipes. */
-  val PipeString              = "\\\n    | "
-  val RedirectAppendString    = "\\\n    >> "
-  val RedirectOverwriteString = "\\\n    > "
+  val PipeString              = " \\\n    | "
+  val RedirectAppendString    = " \\\n    >> "
+  val RedirectOverwriteString = " \\\n    > "
 
   /**
     * A class that represents an empty pipe, that allows for easier construction of pipes with conditional branches.
@@ -145,7 +145,7 @@ object Pipes {
 
     /** Overridden to enforce that it is never called. */
     override def args: Seq[Any] = {
-      throw new NotImplementedError("args should never be called on PipeChain, only command().")
+      throw new NotImplementedError("args should never be called on PipeChain, only commandLine().")
     }
 
     /**

--- a/tasks/src/main/scala/dagr/tasks/package.scala
+++ b/tasks/src/main/scala/dagr/tasks/package.scala
@@ -78,5 +78,7 @@ package object tasks {
     class Bam private() extends SamOrBam
     class Vcf private()
     class Fastq private()
+    class Text private()
+    class Binary private()
   }
 }


### PR DESCRIPTION
I still think the quoting is going a little haywire.  Here's an example that prints out what would go on the command line for FreeBayes.  See the awk command and the quoting of `--region {}`.  What do you think?

---

Command line:
`java -jar target/scala-2.11/dagr-0.1.0-SNAPSHOT.jar --scripts=Testing.scala --config /path/to/example.conf -- Testing`

---

Testing.scala:

```
package dagr.core

import dagr.core.cmdline._
import dagr.core.tasksystem.Pipeline
import dagr.core.execsystem.{Cores, Memory, ResourceSet}
import dagr.tasks.vc._
import java.nio.file.{Path, Paths}
import dagr.tasks.DataTypes._
import dagr.core.tasksystem._

@CLP(description = "Testing")
class Testing extends Pipeline {
  override def build(): Unit = {
      val fb = new FreeBayesGermline(
              ref=Paths.get("/path/to/ref.fasta"),
              targetIntervals=Some(Paths.get("/path/to/intervals.interval_list")),
              bam=List(Paths.get("/path/to/bam.bam")),
              vcf=Paths.get("/path/to/vcf")
              )
      fb.applyResources(resources=new ResourceSet(new Cores(32.0), Memory("8G")))
      val commandLine = fb.getTasks.head.asInstanceOf[Pipe[Nothing,Vcf]].commandLine
      println(commandLine)
  }
}
```
