### PR TITLE
Fix pipeline misspecification error message

### DIFF
--- a/sopt/src/test/scala/dagr/sopt/cmdline/CommandLineParserTest.scala
+++ b/sopt/src/test/scala/dagr/sopt/cmdline/CommandLineParserTest.scala
@@ -303,8 +303,21 @@ class CommandLineParserTest extends UnitSpec with CaptureSystemStreams with Befo
 
   it should "print just the command usage when unknown arguments are passed to command" in {
     Stream(
-      Array[String]("--helloWorld", "CommandLineProgramTesting"),
-      Array[String]("---", "CommandLineProgramTesting")
+      Array[String]("-helloWorld", "CommandLineProgramFive"),
+      Array[String]("-", "CommandLineProgramFive"),
+      Array[String]("-CommandLineProgramFive")
+    ).foreach { args =>
+      val (parser, commandOption, clpOption, output) = TestParsecommandAndClp.parseCommandAndClp[CommandLineProgramTesting,CommandLineProgramOne](args)
+      commandOption shouldBe 'empty
+      clpOption shouldBe 'empty
+      output should include(parser.standardCommandAndSubCommandUsagePreamble(commandClazz=Some(classOf[CommandLineProgramTesting]), subCommandClazz=None))
+      output should not include parser.unknownSubCommandErrorMessage(args.head.substring(1))
+
+    }
+    Stream(
+      Array[String]("--helloWorld", "CommandLineProgramFive"),
+      Array[String]("---", "CommandLineProgramFive"),
+      Array[String]("--CommandLineProgramFive")
     ).foreach { args =>
       val (parser, commandOption, clpOption, output) = TestParsecommandAndClp.parseCommandAndClp[CommandLineProgramTesting,CommandLineProgramOne](args)
       commandOption shouldBe 'empty
@@ -316,14 +329,16 @@ class CommandLineParserTest extends UnitSpec with CaptureSystemStreams with Befo
 
   it should "print just the command usage when an unknown clp name is passed to command" in {
     Stream(
-      Array[String]("--", "CommandLineProgramFive"),
-      Array[String]("--", "CommandLineProgramFive", "--flag")
+      Array[String]("--", "CommandLineProgramOn"),
+      Array[String]("--", "CommandLineProgramOn", "--flag"),
+      Array[String]("CommandLineProgramOn")
     ).foreach { args =>
+      println("testing args: " + args.mkString(", "))
       val (parser, commandOption, clpOption, output) = TestParsecommandAndClp.parseCommandAndClp[CommandLineProgramTesting,CommandLineProgramOne](args)
       commandOption shouldBe 'empty
       clpOption shouldBe 'empty
       output should include(parser.standardCommandAndSubCommandUsagePreamble(commandClazz=Some(classOf[CommandLineProgramTesting]), subCommandClazz=None))
-      output should include(parser.unknownSubCommandErrorMessage("CommandLineProgramFive"))
+      output should include(parser.unknownSubCommandErrorMessage("CommandLineProgramOn"))
     }
   }
 

--- a/sopt/src/test/scala/dagr/sopt/parsing/ArgTokenCollatorTest.scala
+++ b/sopt/src/test/scala/dagr/sopt/parsing/ArgTokenCollatorTest.scala
@@ -104,4 +104,36 @@ class ArgTokenCollatorTest extends UnitSpec {
     ArgTokenCollator.isArgValueOrSameNameArgOptionAndValue(Success(ArgOptionAndValue("opt2", "value")), "opt") shouldBe false
     ArgTokenCollator.isArgValueOrSameNameArgOptionAndValue(Success(ArgOption("opt")), "opt") shouldBe false
   }
+
+  "ArgTokenCollator.takeRemaining" should "return remaining values include those in nextOption when a failure is encountered" in {
+    val args = Seq("-n", "value", "", "-s")
+
+    {
+      val collator = new ArgTokenCollator(new ArgTokenizer(args))
+      collator.takeRemaining shouldBe args
+    }
+    {
+      val collator = new ArgTokenCollator(new ArgTokenizer(args))
+      collator.hasNext shouldBe true
+      val nextVal = collator.next
+      nextVal shouldBe 'success
+      nextVal.get shouldBe ArgOptionAndValues(name="n", values=Seq("value"))
+      collator.takeRemaining shouldBe Seq("", "-s")
+    }
+    {
+      val collator = new ArgTokenCollator(new ArgTokenizer(args))
+      collator.hasNext shouldBe true
+      var nextVal = collator.next
+      nextVal shouldBe 'success
+      nextVal.get shouldBe ArgOptionAndValues(name="n", values=Seq("value"))
+      nextVal = collator.next
+      nextVal shouldBe 'failure
+      collator.takeRemaining shouldBe Seq("", "-s")
+    }
+    {
+      val collator = new ArgTokenCollator(new ArgTokenizer(Seq("val0")))
+      collator.hasNext shouldBe true
+      collator.takeRemaining shouldBe Seq("val0")
+    }
+  }
 }

--- a/sopt/src/test/scala/dagr/sopt/parsing/ArgTokenizerTest.scala
+++ b/sopt/src/test/scala/dagr/sopt/parsing/ArgTokenizerTest.scala
@@ -160,16 +160,18 @@ class ArgTokenizerTest extends UnitSpec {
     }
   }
 
-  it should "throw an [[OptionNameException]] when missing characters a leading dash(es)" in {
+  it should "throw an [[OptionNameException]] when missing a character after a leading dash" in {
     val argList = List(
       List("-"),
-      List("-", "value")
+      List("-", "value"),
+      List("-", "value", "-u", "value")
     )
     argList.foreach { args =>
       val tokenizer = new ArgTokenizer(args:_*)
       val tryVal = tokenizer.next()
       tryVal shouldBe 'failure
       an[OptionNameException] should be thrownBy (throw tryVal.failed.get)
+      tokenizer.takeRemaining shouldBe args
     }
   }
 
@@ -262,7 +264,6 @@ class ArgTokenizerTest extends UnitSpec {
     tokenizer.next() shouldBe Success(ArgOptionAndValue(name="two", value="three"))
     tokenizer.next() shouldBe Success(ArgOption(name="f"))
     tokenizer.next() shouldBe an[Failure[_]]
-    tokenizer.takeRemaining shouldBe Seq("--six")
+    tokenizer.takeRemaining shouldBe Seq("@" + path, "--six")
   }
-
 }

--- a/sopt/src/test/scala/dagr/sopt/parsing/OptionParserTest.scala
+++ b/sopt/src/test/scala/dagr/sopt/parsing/OptionParserTest.scala
@@ -207,4 +207,35 @@ class OptionParserTest extends UnitSpec with PrivateMethodTester {
       }
     }
   }
+
+  "OptionParser.remaining" should "return all arguments that were not parsed correctly" in {
+    {
+      val args = List("val0")
+      val parser = new OptionParser().acceptSingleValue("t").get.acceptSingleValue("s").get.acceptSingleValue("u").get
+      parser.parse(args: _*) shouldBe 'failure
+      parser.remaining should have size 1
+      parser.remaining should be(List("val0"))
+    }
+    {
+      val args = List("-s", "val1", "val2")
+      val parser = new OptionParser().acceptSingleValue("s").get
+      parser.parse(args: _*) shouldBe 'failure
+      parser.remaining should have size 3
+      parser.remaining should be(List("-s", "val1", "val2"))
+    }
+    {
+      val args = List("-t", "val0", "-s", "val1", "val2")
+      val parser = new OptionParser().acceptSingleValue("t").get.acceptSingleValue("s").get
+      parser.parse(args: _*) shouldBe 'failure
+      parser.remaining should have size 3
+      parser.remaining should be(List("-s", "val1", "val2"))
+    }
+    {
+      val args = List("-t", "val0", "-s", "val1", "val2", "-u", "val3")
+      val parser = new OptionParser().acceptSingleValue("t").get.acceptSingleValue("s").get.acceptSingleValue("u").get
+      parser.parse(args: _*) shouldBe 'failure
+      parser.remaining should have size 5
+      parser.remaining should be(List("-s", "val1", "val2", "-u", "val3"))
+    }
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/fulcrumgenomics/dagr/issues/65
1. CommandLineParser will split args by searching for similar sub-command names in the args, for args that have no leading dash.
2. Fixed bug in retrieving the remaining args in the option parser and
   friends.  The iterators will now stop after the first failure.

This commit was like pulling a loose thread, and finding a number of other issues.  I mainly found issues in the various `remaining` and `takeRemaining` methods in `sopt.parsing`.  I wanted to have any arg not consumed returned in the previously mentioned methods, including args that caused a failure.  I ended up not needing these methods in the `CommandLineParser` fix, since I simplified the usage code by having a more intelligent `splitArgs` method.
