### PR TITLE
Added a fail-fast option and changes to that any tasks that are stopped...

### DIFF
--- a/core/src/main/scala/dagr/core/cmdline/DagrCoreMain.scala
+++ b/core/src/main/scala/dagr/core/cmdline/DagrCoreMain.scala
@@ -127,6 +127,8 @@ class DagrCoreMain(
 // TODO: update args with precedence information
   @arg(doc = "Load in a custom configuration into Dagr.  See https://github.com/typesafehub/config for details on the file format.", common = true)
   val config: Option[Path] = None,
+  @arg(doc = "Stop pipelines immediately on detecting the first failed task.", common = true)
+  val failFast: Boolean = false,
   @arg(doc = "Overrides the default scripts directory in the configuration file.", common = true)
   val scriptDir: Option[Path] = None,
   @arg(doc = "Overrides default log directory in the configuration file.", common = true)
@@ -207,7 +209,7 @@ class DagrCoreMain(
     val report  = this.reportPath.getOrElse(throw new IllegalStateException("execute() called before configure()"))
 
     taskMan.addTask(pipeline)
-    taskMan.runToCompletion()
+    taskMan.runToCompletion(this.failFast)
 
     // Write out the execution report
     val pw = new PrintWriter(Io.toWriter(report))

--- a/core/src/main/scala/dagr/core/execsystem/TaskExecutionRunner.scala
+++ b/core/src/main/scala/dagr/core/execsystem/TaskExecutionRunner.scala
@@ -263,7 +263,7 @@ private[core] class TaskExecutionRunner extends TaskExecutionRunnerApi with Lazy
             case None => throw new IllegalStateException(s"Could not find task info for task id '$taskId'.")
           }
           taskInfo.endDate = Some(Instant.now())
-          taskInfo.status = TaskStatus.FAILED_COMMAND
+          taskInfo.status = TaskStatus.STOPPED
           !thread.isAlive // thread is still alive WTF
         case _  => false
       }

--- a/core/src/main/scala/dagr/core/execsystem/TaskManagerLike.scala
+++ b/core/src/main/scala/dagr/core/execsystem/TaskManagerLike.scala
@@ -148,7 +148,7 @@ private[execsystem] trait TaskManagerLike {
     *
     * @return a bi-directional map from the set of tasks to their execution information.
     */
-  def runToCompletion(): BiMap[Task, TaskExecutionInfo]
+  def runToCompletion(failFast: Boolean): BiMap[Task, TaskExecutionInfo]
 
   /** Run a a single iteration of managing tasks.
     *

--- a/core/src/test/scala/dagr/core/execsystem/TaskManagerTest.scala
+++ b/core/src/test/scala/dagr/core/execsystem/TaskManagerTest.scala
@@ -156,7 +156,8 @@ class TaskManagerTest extends UnitSpec with PrivateMethodTester with OptionValue
       sleepMilliseconds    = 10,
       taskManagerResources = Some(TaskManagerResources.infinite),
       scriptsDirectory     = None,
-      simulate             = simulate)
+      simulate             = simulate,
+      failFast             = true)
 
     map.containsKey(task) should be(true)
 
@@ -186,11 +187,10 @@ class TaskManagerTest extends UnitSpec with PrivateMethodTester with OptionValue
 
     val taskManager: TaskManager = getDefaultTaskManager(sleepMilliseconds=1)
     taskManager.addTasks(longTask, failedTask)
-    taskManager.runToCompletion()
+    taskManager.runToCompletion(failFast=true)
     taskManager.taskStatusFor(failedTask).value should be(TaskStatus.FAILED_COMMAND)
     taskManager.graphNodeStateFor(failedTask).value should be(GraphNodeState.COMPLETED)
-    taskManager.taskStatusFor(longTask).value should be(TaskStatus.FAILED_COMMAND)
-    taskManager.graphNodeStateFor(longTask).value should be(GraphNodeState.COMPLETED)
+    taskManager.taskStatusFor(longTask).value should be(TaskStatus.STOPPED)
   }
 
   // ******************************************
@@ -211,7 +211,7 @@ class TaskManagerTest extends UnitSpec with PrivateMethodTester with OptionValue
                     originalGraphNodeState: GraphNodeState.Value,
                     taskManager: TaskManager): Unit = {
     // run it once, make sure tasks that are failed are not marked as completed
-    taskManager.runToCompletion()
+    taskManager.runToCompletion(failFast=true)
 
     // the task identifier for 'original' should now be found
     val originalTaskId: TaskId = taskManager.taskFor(original).value
@@ -795,7 +795,8 @@ class TaskManagerTest extends UnitSpec with PrivateMethodTester with OptionValue
       TaskManager.run(
         new HungryPipeline,
         sleepMilliseconds = 1,
-        taskManagerResources = Some(TaskManagerResources(systemCores, Resource.parseSizeToBytes("8g").toLong, 0.toLong))
+        taskManagerResources = Some(TaskManagerResources(systemCores, Resource.parseSizeToBytes("8g").toLong, 0.toLong)),
+        failFast=true
       )
       maxAllocatedCores should be <= systemCores
     }
@@ -830,7 +831,7 @@ class TaskManagerTest extends UnitSpec with PrivateMethodTester with OptionValue
     taskManager.addTasks(tasks)
 
     // run the tasks
-    taskManager.runToCompletion()
+    taskManager.runToCompletion(failFast=true)
 
     // make sure all tasks have been completed
     tasks.foreach { task =>
@@ -863,7 +864,7 @@ class TaskManagerTest extends UnitSpec with PrivateMethodTester with OptionValue
     taskManager.addTasks(pipeline)
 
     // run the tasks
-    taskManager.runToCompletion()
+    taskManager.runToCompletion(failFast=true)
 
     // get and check the info
     val pipelineInfo: TaskExecutionInfo = getAndTestTaskExecutionInfo(taskManager, pipeline)
@@ -902,7 +903,7 @@ class TaskManagerTest extends UnitSpec with PrivateMethodTester with OptionValue
     taskManager.addTasks(outerPipeline)
 
     // run the tasks
-    taskManager.runToCompletion()
+    taskManager.runToCompletion(failFast=true)
 
     // get and check the info
     val firstTaskInfo : TaskExecutionInfo = getAndTestTaskExecutionInfo(taskManager, firstTask)


### PR DESCRIPTION
...by dagr during shutdown end in status `STOPPED` instead of `FAILED`.
