### PR TITLE
Made it so that pipelines can prefix and suffix task names easily.

### DIFF
--- a/core/src/main/scala/dagr/core/tasksystem/NoOpInJvmTask.scala
+++ b/core/src/main/scala/dagr/core/tasksystem/NoOpInJvmTask.scala
@@ -26,6 +26,7 @@ package dagr.core.tasksystem
 /**
  * Trivial No-Op task that runs inside the JVM and does nothing.
  */
-class NoOpInJvmTask(name: String) extends SimpleInJvmTask {
+class NoOpInJvmTask(taskName: String) extends SimpleInJvmTask {
+  this.name = taskName
   override def run(): Unit = Unit
 }

--- a/core/src/main/scala/dagr/core/tasksystem/Pipeline.scala
+++ b/core/src/main/scala/dagr/core/tasksystem/Pipeline.scala
@@ -28,7 +28,10 @@ import java.nio.file.Path
 import dagr.commons.util.LazyLogging
 
 /** Simple trait to track tasks within a pipeline */
-abstract class Pipeline(val outputDirectory: Option[Path] = None) extends Task with LazyLogging {
+abstract class Pipeline(val outputDirectory: Option[Path] = None,
+                        private var prefix: Option[String] = None,
+                        private var suffix: Option[String] = None
+                       ) extends Task with LazyLogging {
   private val tasks = new scala.collection.mutable.LinkedHashSet[Task]()
 
   /** A name exposed to sub-classes that can be treated like a Task, to add root tasks. */
@@ -59,6 +62,17 @@ abstract class Pipeline(val outputDirectory: Option[Path] = None) extends Task w
   final override def getTasks: Traversable[_ <: Task] = {
     build()
     tasks.toList.foreach(addChildren)
+
+    // Do the necessary prefixing and suffixing of task names
+    if (prefix.isDefined || suffix.isDefined) {
+      tasks.foreach {
+        case p: Pipeline =>
+          p.prefix = if (p.prefix.isEmpty) prefix else p.prefix.map(prefix.getOrElse("") + _)
+          p.suffix = if (p.suffix.isEmpty) suffix else p.suffix.map(suffix.getOrElse("") + _)
+        case t: Task     => t.name = prefix.getOrElse("") + t.name + suffix.getOrElse("")
+      }
+    }
+
     tasks.toList
   }
 

--- a/core/src/main/scala/dagr/core/tasksystem/Task.scala
+++ b/core/src/main/scala/dagr/core/tasksystem/Task.scala
@@ -153,9 +153,6 @@ object Task {
  *    method will be called until the task no longer wishes to retry or succeeds.
  */
 trait Task extends Dependable {
-  // A string set by the enclosing workflow to distinguish the task
-  private[tasksystem] var contextName : Option[String] = None
-
   /** The unique id given to this task by the execution system, or None if not being tracked. */
   private[core] var _taskInfo : Option[TaskExecutionInfo] = None
   private[core] def taskInfo : TaskExecutionInfo = _taskInfo.getOrElse(unreachable(s"Task id should be defined for task '$name'"))

--- a/core/src/test/scala/dagr/core/execsystem/NaiveSchedulerTest.scala
+++ b/core/src/test/scala/dagr/core/execsystem/NaiveSchedulerTest.scala
@@ -156,7 +156,7 @@ class NaiveSchedulerTest extends UnitSpec with LazyLogging {
     // resources.  This way, two of each should be scheduled.
     for (i <- 1 to 3) {
       readyTasks += new ShellCommand("exit 0") withName "system task" requires(Cores(1), Memory("1G"))
-      readyTasks += new NoOpInJvmTask(name = "in jvm task") requires(Cores(1), Memory("16M"))
+      readyTasks += new NoOpInJvmTask(taskName = "in jvm task") requires(Cores(1), Memory("16M"))
     }
     val systemCores: Cores = Cores(4)
     val systemMemory: Memory = Memory("4G")

--- a/core/src/test/scala/dagr/core/execsystem/TaskManagerTest.scala
+++ b/core/src/test/scala/dagr/core/execsystem/TaskManagerTest.scala
@@ -661,8 +661,8 @@ class TaskManagerTest extends UnitSpec with PrivateMethodTester with OptionValue
 
   class SimplePipeline(name: String) extends Pipeline {
     withName(name)
-    val firstTask: UnitTask = new NoOpInJvmTask(name=name+"-1")
-    val secondTask: UnitTask = new NoOpInJvmTask(name=name+"-2")
+    val firstTask: UnitTask = new NoOpInJvmTask(taskName=name+"-1")
+    val secondTask: UnitTask = new NoOpInJvmTask(taskName=name+"-2")
     root ==> (firstTask :: secondTask) // do this here so we can call getTasks repeatedly
     def build(): Unit = {}
   }

--- a/core/src/test/scala/dagr/core/tasksystem/PipelineTest.scala
+++ b/core/src/test/scala/dagr/core/tasksystem/PipelineTest.scala
@@ -1,0 +1,79 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package dagr.core.tasksystem
+
+import dagr.commons.util.UnitSpec
+
+/**
+ * Test that are specific to the Pipeline class
+ */
+class PipelineTest extends UnitSpec {
+  def named(s: String) = new NoOpInJvmTask(s)
+
+  "Pipeline" should "not touch task names if no prefix or suffix is given" in {
+    class TestPipeline extends Pipeline {
+      override def build(): Unit = root ==> named("hello") ==> named("world")
+    }
+    val ts = new TestPipeline().getTasks.map(_.name).toList.sorted
+    ts shouldBe List("hello", "world")
+  }
+
+  it should "add prefixes only to task names when there is no suffix" in {
+    class TestPipeline extends Pipeline(prefix=Some("foo.")) {
+      override def build(): Unit = root ==> named("hello") ==> named("world")
+    }
+    val ts = new TestPipeline().getTasks.map(_.name).toList.sorted
+    ts shouldBe List("foo.hello", "foo.world")
+  }
+
+  it should "add suffixes only to task names when there is no prefix" in {
+    class TestPipeline extends Pipeline(suffix=Some(".foo")) {
+      override def build(): Unit = root ==> named("hello") ==> named("world")
+    }
+    val ts = new TestPipeline().getTasks.map(_.name).toList.sorted
+    ts shouldBe List("hello.foo", "world.foo")
+  }
+
+  it should "add prefixes and suffixes to task names when both are supplied" in {
+    class TestPipeline extends Pipeline(prefix=Some("before."), suffix=Some(".after")) {
+      override def build(): Unit = root ==> named("hello") ==> named("world")
+    }
+    val ts = new TestPipeline().getTasks.map(_.name).toList.sorted
+    ts shouldBe List("before.hello.after", "before.world.after")
+  }
+
+  it should "stack prefixes and suffixes for nested pipelines" in {
+    class InnerPipeline extends Pipeline(prefix=Some("innerbefore."), suffix=Some(".innerafter")) {
+      override def build(): Unit = root ==> named("hello") ==> named("world")
+    }
+    class OuterPipeline extends Pipeline(prefix=Some("outerbefore."), suffix=Some(".outerafter")) {
+      override def build(): Unit = root ==> new InnerPipeline
+    }
+
+    val ts = new OuterPipeline().getTasks.head.getTasks.map(_.name).toList.sorted
+    ts shouldBe List("outerbefore.innerbefore.hello.outerafter.innerafter",
+                     "outerbefore.innerbefore.world.outerafter.innerafter")
+  }
+}

--- a/pipelines/src/main/scala/dagr/pipelines/DnaResequencingFromFastqPipeline.scala
+++ b/pipelines/src/main/scala/dagr/pipelines/DnaResequencingFromFastqPipeline.scala
@@ -65,7 +65,7 @@ class DnaResequencingFromFastqPipeline
   @arg(doc="Path to a temporary directory.")                       val tmp: Path,
   @arg(flag="o", doc="The output directory to which files are written.")  val out: DirPath,
   @arg(doc="The basename for all output files. Uses library if omitted.") val basename: Option[FilenamePrefix]
-) extends Pipeline(outputDirectory = Some(out)) {
+) extends Pipeline(outputDirectory = Some(out), suffix=Some("." + library)) {
   name = getClass.getSimpleName
 
   // Validation logic as constructor code


### PR DESCRIPTION
@nh13 Take a look at this.  The change allows pipelines to have a prefix and/or suffix or neither, which is then pre/app-ended to task names when `getTasks` is called.  This means that you can, e.g. have a pipeline for processing a sequencing run with suffix `.AD09F`, and then per-sample pipeline with their own suffixes like `.SpecialSample`, and then your job names will get `.AD09F.SpecialSample` appended to them - which is then used in naming scripts, logs and in various logging/reporting.

A couple of things for discussion:
1. Should pipeline check, and if missing, add `.` before suffixes and after prefixes?  On the upside it makes things much simpler for users, on the downside if you prefer a separator other than `.` you can't.
2. Should `Pipeline` be responsible for making these file-name safe, or is that the responsibility of the code that creates scripts and logs? (I think the latter since task names can also be problematic).
