### PR TITLE
Made it so that pipelines can prefix and suffix task names easily.

### DIFF
--- a/core/src/main/scala/dagr/core/execsystem/TaskManager.scala
+++ b/core/src/main/scala/dagr/core/execsystem/TaskManager.scala
@@ -158,7 +158,7 @@ class TaskManager(taskManagerResources: TaskManagerResources = TaskManagerDefaul
   private[execsystem] def getTaskManagerResources: TaskManagerResources = taskManagerResources
 
   private def pathFor(task: Task, taskId: TaskId, directory: Path, ext: String): Path = {
-    val sanitizedName: String = PathUtil.sanitizeFileName(task.name)
+    val sanitizedName: String = PathUtil.sanitizeFileName(task.contextName.getOrElse(task.name))
     PathUtil.pathTo(directory.toString, s"$sanitizedName.$taskId.$ext")
   }
 

--- a/core/src/main/scala/dagr/core/tasksystem/NoOpInJvmTask.scala
+++ b/core/src/main/scala/dagr/core/tasksystem/NoOpInJvmTask.scala
@@ -26,6 +26,7 @@ package dagr.core.tasksystem
 /**
  * Trivial No-Op task that runs inside the JVM and does nothing.
  */
-class NoOpInJvmTask(name: String) extends SimpleInJvmTask {
+class NoOpInJvmTask(taskName: String) extends SimpleInJvmTask {
+  this.name = taskName
   override def run(): Unit = Unit
 }

--- a/core/src/main/scala/dagr/core/tasksystem/Task.scala
+++ b/core/src/main/scala/dagr/core/tasksystem/Task.scala
@@ -153,15 +153,15 @@ object Task {
  *    method will be called until the task no longer wishes to retry or succeeds.
  */
 trait Task extends Dependable {
-  // A string set by the enclosing workflow to distinguish the task
-  private[tasksystem] var contextName : Option[String] = None
-
   /** The unique id given to this task by the execution system, or None if not being tracked. */
   private[core] var _taskInfo : Option[TaskExecutionInfo] = None
   private[core] def taskInfo : TaskExecutionInfo = _taskInfo.getOrElse(unreachable(s"Task id should be defined for task '$name'"))
 
   /** The name of the task. */
   var name: String = getClass.getSimpleName
+
+  /** A string set by an enclosing task to distinguish the task from other similarly named tasks. */
+  var contextName : Option[String] = None
 
   /* The set of tasks that this task depends on. */
   private val dependsOnTasks    = new ListBuffer[Task]()

--- a/core/src/test/scala/dagr/core/execsystem/NaiveSchedulerTest.scala
+++ b/core/src/test/scala/dagr/core/execsystem/NaiveSchedulerTest.scala
@@ -156,7 +156,7 @@ class NaiveSchedulerTest extends UnitSpec with LazyLogging {
     // resources.  This way, two of each should be scheduled.
     for (i <- 1 to 3) {
       readyTasks += new ShellCommand("exit 0") withName "system task" requires(Cores(1), Memory("1G"))
-      readyTasks += new NoOpInJvmTask(name = "in jvm task") requires(Cores(1), Memory("16M"))
+      readyTasks += new NoOpInJvmTask(taskName = "in jvm task") requires(Cores(1), Memory("16M"))
     }
     val systemCores: Cores = Cores(4)
     val systemMemory: Memory = Memory("4G")

--- a/core/src/test/scala/dagr/core/execsystem/TaskManagerTest.scala
+++ b/core/src/test/scala/dagr/core/execsystem/TaskManagerTest.scala
@@ -661,8 +661,8 @@ class TaskManagerTest extends UnitSpec with PrivateMethodTester with OptionValue
 
   class SimplePipeline(name: String) extends Pipeline {
     withName(name)
-    val firstTask: UnitTask = new NoOpInJvmTask(name=name+"-1")
-    val secondTask: UnitTask = new NoOpInJvmTask(name=name+"-2")
+    val firstTask: UnitTask = new NoOpInJvmTask(taskName=name+"-1")
+    val secondTask: UnitTask = new NoOpInJvmTask(taskName=name+"-2")
     root ==> (firstTask :: secondTask) // do this here so we can call getTasks repeatedly
     def build(): Unit = {}
   }

--- a/core/src/test/scala/dagr/core/tasksystem/PipelineTest.scala
+++ b/core/src/test/scala/dagr/core/tasksystem/PipelineTest.scala
@@ -1,0 +1,81 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package dagr.core.tasksystem
+
+import dagr.commons.util.UnitSpec
+
+/**
+ * Test that are specific to the Pipeline class
+ */
+class PipelineTest extends UnitSpec {
+  def named(s: String) = new NoOpInJvmTask(s)
+
+  "Pipeline" should "not touch task names if no prefix or suffix is given" in {
+    class TestPipeline extends Pipeline {
+      override def build(): Unit = root ==> named("hello") ==> named("world")
+    }
+    val ts = new TestPipeline().getTasks.map(_.name).toList.sorted
+    ts shouldBe List("hello", "world")
+  }
+
+  it should "add prefixes only to task names when there is no suffix" in {
+    class TestPipeline extends Pipeline(prefix=Some("foo.")) {
+      override def build(): Unit = root ==> named("hello") ==> named("world")
+    }
+    new TestPipeline().getTasks.map(_.name).toList.sorted shouldBe List("hello", "world")
+    new TestPipeline().getTasks.map(_.contextName).toList.sorted shouldBe List(Some("foo.hello"), Some("foo.world"))
+  }
+
+  it should "add suffixes only to task names when there is no prefix" in {
+    class TestPipeline extends Pipeline(suffix=Some(".foo")) {
+      override def build(): Unit = root ==> named("hello") ==> named("world")
+    }
+    new TestPipeline().getTasks.map(_.name).toList.sorted shouldBe List("hello", "world")
+    new TestPipeline().getTasks.map(_.contextName).toList.sorted shouldBe List(Some("hello.foo"), Some("world.foo"))
+  }
+
+  it should "add prefixes and suffixes to task names when both are supplied" in {
+    class TestPipeline extends Pipeline(prefix=Some("before."), suffix=Some(".after")) {
+      override def build(): Unit = root ==> named("hello") ==> named("world")
+    }
+    new TestPipeline().getTasks.map(_.name).toList.sorted shouldBe List("hello", "world")
+    new TestPipeline().getTasks.map(_.contextName).toList.sorted shouldBe List(Some("before.hello.after"), Some("before.world.after"))
+  }
+
+  it should "stack prefixes and suffixes for nested pipelines" in {
+    class InnerPipeline extends Pipeline(prefix=Some("innerbefore."), suffix=Some(".innerafter")) {
+      override def build(): Unit = root ==> named("hello") ==> named("world")
+    }
+    class OuterPipeline extends Pipeline(prefix=Some("outerbefore."), suffix=Some(".outerafter")) {
+      override def build(): Unit = root ==> new InnerPipeline
+    }
+
+    val names = new OuterPipeline().getTasks.head.getTasks.map(_.name).toList.sorted
+    names shouldBe List("hello", "world")
+    val contextNames = new OuterPipeline().getTasks.head.getTasks.map(_.contextName).toList.sorted
+    contextNames shouldBe List(Some("outerbefore.innerbefore.hello.outerafter.innerafter"),
+      Some("outerbefore.innerbefore.world.outerafter.innerafter"))
+  }
+}


### PR DESCRIPTION
@tfenne here's an example of an alternative implementation of #114.
