### PR TITLE
Added a way to request that individual process task arguments not get escaped.

### DIFF
--- a/core/src/test/scala/dagr/core/tasksystem/TaskTest.scala
+++ b/core/src/test/scala/dagr/core/tasksystem/TaskTest.scala
@@ -412,5 +412,13 @@ class TaskTest extends UnitSpec with LazyLogging {
     it should "quote all special character in arguments that have single quotes" in {
       P("it's cold outside", "what?!", "I'm a *").commandLine shouldBe """it\'s\ cold\ outside 'what?!' I\'m\ a\ \*"""
     }
+
+    it should "not escape arguments that have requested to avoid being escaped" in {
+       val cmd = new ProcessTask with FixedResources {
+         override def args: Seq[Any] = "echo" :: "bad" :: "developer" :: unescaped("&&") :: "exit" :: "1" :: Nil
+       }.commandLine
+
+      cmd shouldBe "echo bad developer && exit 1"
+    }
   }
 }


### PR DESCRIPTION
@nh13 This is an alternative to #121, to let you do nasty things by by-passing the argument escaping on a per-argument basis.  For the record, I think both this and the enhancement described in #121 are a bad idea - both further couple or expose the fact that execution happens through a shell (and even a specific shell with specific semantics).  I think that is undesirable.  

This at least seems more subtle though, and requires a little more effort from users (you'll have to write your own `ProcessTask` subclass in order to access `unescaped`).
