### PR TITLE
Refactored Io into a trait and object pair to make it easier to extend.

### DIFF
--- a/commons/src/test/scala/dagr/commons/io/IoTest.scala
+++ b/commons/src/test/scala/dagr/commons/io/IoTest.scala
@@ -27,8 +27,6 @@ import java.nio.file.{Files, Path}
 
 import dagr.commons.util.UnitSpec
 
-import scala.io.Source
-
 /**
  * Tests for various methods in the Io class
  */
@@ -160,7 +158,7 @@ class IoTest extends UnitSpec {
     val lines = List("hello world", "what was that?", "oh noes!!!!!", "goodbye cruel world.")
     val path = Files.createTempFile("test", "file")
     Io.writeLines(path, lines)
-    val roundtripped = Source.fromFile(path.toFile).getLines().toList
+    val roundtripped = Io.readLines(path).toList
     Files.delete(path)
 
     roundtripped shouldBe lines


### PR DESCRIPTION
Made sure that all open() type methods route through a pair of methods for easy overriding.
Added a method to read lines from a file that takes a Path as input and uses the standard method to open the file.
