### PR TITLE
Descriptions and versions were not being displayed in usage messages.

### DIFF
--- a/sopt/src/test/scala/dagr/sopt/cmdline/CommandLineProgramParserTest.scala
+++ b/sopt/src/test/scala/dagr/sopt/cmdline/CommandLineProgramParserTest.scala
@@ -575,21 +575,21 @@ with CommandLineParserStrings with CaptureSystemStreams with BeforeAndAfterAll {
   }
 
   "CommandLineProgramParser.usage" should "print out no arguments when no arguments are present" in {
-    val usage = parser(classOf[NoArguments]).usage(printCommon = false, withPreamble = true, withSpecial = false)
+    val usage = parser(classOf[NoArguments]).usage(printCommon = false, withVersion = true, withSpecial = false)
     usage should not include (RequiredArguments)
     usage should not include (OptionalArguments)
     usage should include (UsagePrefix)
   }
 
   it should "print out only optional arguments when only optional arguments are present" in {
-    val usage = parser(classOf[OptionalOnlyArguments]).usage(printCommon = false, withPreamble = false, withSpecial = false)
+    val usage = parser(classOf[OptionalOnlyArguments]).usage(printCommon = false, withVersion = false, withSpecial = false)
     val reqIndex = usage.indexOf(RequiredArguments)
     reqIndex should be < 0
     usage should include (OptionalArguments)
   }
 
   it should "print out only required arguments when only required arguments are present and null default value" in {
-    val usage = parser(classOf[RequiredOnlyArguments]).usage(printCommon = false, withPreamble = false, withSpecial = false)
+    val usage = parser(classOf[RequiredOnlyArguments]).usage(printCommon = false, withVersion = false, withSpecial = false)
     val reqIndex = usage.indexOf(RequiredArguments)
     reqIndex should be > 0
     usage.indexOf(OptionalArguments, reqIndex) should be < 0
@@ -600,7 +600,7 @@ with CommandLineParserStrings with CaptureSystemStreams with BeforeAndAfterAll {
     * emitted before optional ones.  Assumes both optional and required arguments are present.
     */
   def validateRequiredOptionalUsage(task: Any, printCommon: Boolean): Unit = {
-    val usage = parser(task.getClass).usage(printCommon = false, withPreamble = false, withSpecial = false)
+    val usage = parser(task.getClass).usage(printCommon = false, withVersion = false, withSpecial = false)
     usage should include (RequiredArguments)
     usage should include (OptionalArguments)
     usage.indexOf(RequiredArguments) should be < usage.indexOf(OptionalArguments)
@@ -614,41 +614,42 @@ with CommandLineParserStrings with CaptureSystemStreams with BeforeAndAfterAll {
 
   it should "print out an explanation of mutually exclusive arguments" in {
     val task = new MutexArguments
-    val usage = parser(task.getClass).usage(printCommon = false, withPreamble = false, withSpecial = false)
+    val usage = parser(task.getClass).usage(printCommon = false, withVersion = false, withSpecial = false)
     usage should include (mutexErrorHeader)
   }
 
   it should "not print out default values with None, empty collections, or required argument when no defaults are given" in {
-    val usage = parser(classOf[NoDefaultValueStringsClass]).usage(printCommon = false, withPreamble = false, withSpecial = false)
+    val usage = parser(classOf[NoDefaultValueStringsClass]).usage(printCommon = false, withVersion = false, withSpecial = false)
     usage should not include "empty"
     usage should not include "Nil"
     usage should not include "None"
   }
 
   it should "not print out default values with None, empty collections, or required argument when empty defaults are given" in {
-    val usage = parser(classOf[EmptyDefaultValueStringsClass]).usage(printCommon = false, withPreamble = false, withSpecial = false)
+    val usage = parser(classOf[EmptyDefaultValueStringsClass]).usage(printCommon = false, withVersion = false, withSpecial = false)
     usage should not include "empty"
     usage should not include "Nil"
     usage should not include "None"
   }
 
   it should "print out default values with Some(x), non-empty collections, a required argument with a non-None or non-empty collection default" in {
-    val usage = parser(classOf[NonEmptyDefaultValueStringsClass]).usage(printCommon = false, withPreamble = false, withSpecial = false)
+    val usage = parser(classOf[NonEmptyDefaultValueStringsClass]).usage(printCommon = false, withVersion = false, withSpecial = false)
     "abcde".foreach { c =>
       usage should include (s"unique-value-$c")
     }
   }
 
   it should "put the clp description on the next line for a really long argument name" in {
-    val usage = parser(classOf[CommandLineProgramReallyLongArg]).usage(printCommon = false, withPreamble = false, withSpecial = false)
+    val usage = parser(classOf[CommandLineProgramReallyLongArg]).usage(printCommon = false, withVersion = false, withSpecial = false)
+    System.err.println("usage: " + usage)
     usage
       .split("\n")
-      .filter(str => str.contains("argument"))
+      .filter(str => str.contains("--argument"))
       .foreach(str => str should endWith ("tttttttttt=String"))
   }
 
   it should "pad the clp description on the same line for a short argument name" in {
-    val usage = parser(classOf[CommandLineProgramShortArg]).usage(printCommon = false, withPreamble = false, withSpecial = false)
+    val usage = parser(classOf[CommandLineProgramShortArg]).usage(printCommon = false, withVersion = false, withSpecial = false)
     usage
       .split("\n")
       .filter(str => str.contains("argument"))
@@ -656,18 +657,18 @@ with CommandLineParserStrings with CaptureSystemStreams with BeforeAndAfterAll {
   }
 
   it should "print enum values in the  usage" in {
-    val usage = parser(classOf[GoodEnumClass]).usage(printCommon = false, withPreamble = false, withSpecial = false)
+    val usage = parser(classOf[GoodEnumClass]).usage(printCommon = false, withVersion = false, withSpecial = false)
     GoodEnum.values.foreach(e =>
       usage should include (e.name())
     )
   }
 
   it should "throw an exception when an enum has no values" in {
-    an[ReflectionException] should be thrownBy parser(classOf[BadEnumClass]).usage(printCommon = false, withPreamble = false, withSpecial = false)
+    an[ReflectionException] should be thrownBy parser(classOf[BadEnumClass]).usage(printCommon = false, withVersion = false, withSpecial = false)
   }
 
   it should "format a long description" in {
-    val usage = parser(classOf[SomeDescription]).usage(printCommon = false, withPreamble = true, withSpecial = false)
+    val usage = parser(classOf[SomeDescription]).usage(printCommon = false, withVersion = true, withSpecial = false)
     val start = usage.indexOf("<START>")
     val end = usage.indexOf("<END>")
     start should be > 0

--- a/sopt/src/test/scala/dagr/sopt/cmdline/testing/clps/CommandLinePrograms.scala
+++ b/sopt/src/test/scala/dagr/sopt/cmdline/testing/clps/CommandLinePrograms.scala
@@ -48,7 +48,7 @@ private[cmdline] case class CommandLineProgramThree
 private[cmdline] case class CommandLineProgramFour
 (@arg var argument: String = "default", @arg var flag: Boolean = false) extends CommandLineProgramTesting
 
-@clp(description = "", group = classOf[TestGroup], hidden = true)
+@clp(description = "This is a description", group = classOf[TestGroup], hidden = true)
 private[cmdline] case class CommandLineProgramReallyLongArg
 (
   @arg var argumentttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt: String


### PR DESCRIPTION
@tfenne fixes https://github.com/fulcrumgenomics/dagr/issues/133.  Can you please verify it produces the intended behavior?

The whole testing of usage and error messages for command line programs is a big PITA, and doesn't cover all the cases (obviously).  Perhaps a better set of tests would include a few common usages of `sopt`:
1. A single CLP with options.
2. A CLP with sub-commands.  The CLP has no options but the sub-commands do.  Example: `fgbio`.
3. A CLP with sub-commands, with bot the CLP and the sub-commands having options.  Example: `dagr`.

We save in a test resource file the text we want them to print for usages, then make sure they match fully.  I think the two major test cases are help messages and when the sub-command list is printed for 2 & 3.  

I don't think this PR is blocked by this, but I thought I would start the discussion here, and we can make it into an issue if you agree.
