### PR TITLE
Fixed DeleteFiles to close the stupid streams returned by Files.list(dir)

### DIFF
--- a/tasks/src/main/scala/dagr/tasks/misc/DeleteFiles.scala
+++ b/tasks/src/main/scala/dagr/tasks/misc/DeleteFiles.scala
@@ -43,7 +43,9 @@ class DeleteFiles(val paths: FilePath*) extends SimpleInJvmTask {
   /** Recursive implementation that recurses if path is a directory, then deletes the path. */
   private def delete(path: Path): Unit = {
     if (Files.isDirectory(path)) {
-      val children = Files.list(path).collect(Collectors.toList())
+      val childStream = Files.list(path)
+      val children = childStream.collect(Collectors.toList())
+      childStream.close()
       children.foreach(this.delete)
     }
 


### PR DESCRIPTION
OMFG, I can't believe that java.nio.file.Files.list(Path) returns a `Stream` that doesn't auto-close when you hit the end of it, so you end up leaking file handles.  WTF?
