### PR TITLE
PicardMetricsTask is now a trait.

### DIFF
--- a/tasks/src/main/scala/dagr/tasks/picard/CollectAlignmentSummaryMetrics.scala
+++ b/tasks/src/main/scala/dagr/tasks/picard/CollectAlignmentSummaryMetrics.scala
@@ -34,11 +34,11 @@ object CollectAlignmentSummaryMetrics {
    def metricsExtension: String = ".alignment_summary_metrics"
 }
 
-class CollectAlignmentSummaryMetrics(in: PathToBam,
-                                     prefix: Option[Path],
+class CollectAlignmentSummaryMetrics(override val in: PathToBam,
+                                     override val prefix: Option[Path],
                                      ref: PathToFasta,
                                      assumeSorted: Boolean = true)
-  extends PicardMetricsTask(in=in, prefix=prefix) {
+  extends PicardTask with PicardMetricsTask {
 
   override def metricsExtension: String = CollectAlignmentSummaryMetrics.metricsExtension
 

--- a/tasks/src/main/scala/dagr/tasks/picard/CollectGcBiasMetrics.scala
+++ b/tasks/src/main/scala/dagr/tasks/picard/CollectGcBiasMetrics.scala
@@ -36,10 +36,10 @@ object CollectGcBiasMetrics {
   val DetailMetricsExtension:  String = ".gc_bias.detail_metrics"
 }
 
-class CollectGcBiasMetrics(in: PathToBam,
-                           prefix: Option[Path],
+class CollectGcBiasMetrics(override val in: PathToBam,
+                           override val prefix: Option[Path],
                            ref: PathToFasta)
-  extends PicardMetricsTask(in = in, prefix = prefix) {
+  extends PicardTask with PicardMetricsTask {
 
   override def metricsExtension: String = ""
 

--- a/tasks/src/main/scala/dagr/tasks/picard/CollectHsMetrics.scala
+++ b/tasks/src/main/scala/dagr/tasks/picard/CollectHsMetrics.scala
@@ -37,13 +37,13 @@ object CollectHsMetrics {
   def baitSetName(baitSetIntervals: Path): String = PathUtil.basename(baitSetIntervals.toString, trimExt=true)
 }
 
-class CollectHsMetrics(in: PathToBam,
-                       prefix: Option[Path] = None,
+class CollectHsMetrics(override val in: PathToBam,
+                       override val prefix: Option[Path] = None,
                        ref: PathToFasta,
                        targets: PathToIntervals,
                        baits: Option[PathToIntervals] = None,
                        baitSetName: Option[String] = None)
-  extends PicardMetricsTask(in=in, prefix=prefix) {
+  extends PicardTask with PicardMetricsTask {
 
   override def metricsExtension: String = CollectHsMetrics.MetricsExtension
 

--- a/tasks/src/main/scala/dagr/tasks/picard/CollectInsertSizeMetrics.scala
+++ b/tasks/src/main/scala/dagr/tasks/picard/CollectInsertSizeMetrics.scala
@@ -32,11 +32,11 @@ object CollectInsertSizeMetrics {
   def metricsExtension: String = ".insert_size_metrics"
 }
 
-class CollectInsertSizeMetrics(in: PathToBam,
-                               prefix: Option[PathPrefix],
+class CollectInsertSizeMetrics(override val in: PathToBam,
+                               override val prefix: Option[PathPrefix],
                                val minimumPercent: Option[Double] = None,
                                val width: Option[Int] = None)
-  extends PicardMetricsTask(in=in, prefix=prefix) {
+  extends PicardTask with PicardMetricsTask {
   override def metricsExtension: String = CollectInsertSizeMetrics.metricsExtension
 
   override protected def addPicardArgs(buffer: ListBuffer[Any]): Unit = {

--- a/tasks/src/main/scala/dagr/tasks/picard/CollectMultipleMetrics.scala
+++ b/tasks/src/main/scala/dagr/tasks/picard/CollectMultipleMetrics.scala
@@ -31,13 +31,13 @@ import picard.analysis.CollectMultipleMetrics.Program
 
 import scala.collection.mutable.ListBuffer
 
-class CollectMultipleMetrics(in: PathToBam,
-                             prefix: Option[Path] = None,
+class CollectMultipleMetrics(override val in: PathToBam,
+                             override val prefix: Option[Path] = None,
                              ref: PathToFasta,
                              assumeSorted: Boolean = true,
                              programs: Seq[Program] = Program.values().toSeq,
                              fileExtension: Option[String] = Some("." + PicardOutput.Text.toString))
-  extends PicardMetricsTask(in = in, prefix = prefix) {
+  extends PicardTask with PicardMetricsTask {
 
   // Since we do not actually want any extensions, the tool will do that itself
   override def metricsExtension: String = ""

--- a/tasks/src/main/scala/dagr/tasks/picard/CollectTargetedPcrMetrics.scala
+++ b/tasks/src/main/scala/dagr/tasks/picard/CollectTargetedPcrMetrics.scala
@@ -39,11 +39,11 @@ object CollectTargetedPcrMetrics {
   def metricsExtension: String = ".targeted_pcr_metrics"
 }
 
-class CollectTargetedPcrMetrics(in: PathToBam,
-                                prefix: Option[Path],
+class CollectTargetedPcrMetrics(override val in: PathToBam,
+                                override val prefix: Option[Path],
                                 ref: PathToFasta,
                                 targets: PathToIntervals)
-  extends PicardMetricsTask(in = in, prefix = prefix) {
+  extends PicardTask with PicardMetricsTask{
 
   override def metricsExtension: String = CollectTargetedPcrMetrics.metricsExtension
 

--- a/tasks/src/main/scala/dagr/tasks/picard/CollectWgsMetrics.scala
+++ b/tasks/src/main/scala/dagr/tasks/picard/CollectWgsMetrics.scala
@@ -34,10 +34,10 @@ object CollectWgsMetrics {
   val MetricsExtension: String = ".wgs_metrics"
 }
 
-class CollectWgsMetrics(in: PathToBam,
-                        prefix: Option[Path],
+class CollectWgsMetrics(override val in: PathToBam,
+                        override val prefix: Option[Path],
                         ref: PathToFasta)
-  extends PicardMetricsTask(in = in, prefix = prefix) {
+  extends PicardTask with PicardMetricsTask {
 
   override def metricsExtension: String = CollectWgsMetrics.MetricsExtension
 

--- a/tasks/src/main/scala/dagr/tasks/picard/EstimateLibraryComplexity.scala
+++ b/tasks/src/main/scala/dagr/tasks/picard/EstimateLibraryComplexity.scala
@@ -42,14 +42,14 @@ object EstimateLibraryComplexity {
   val MetricsExtension = ".els_duplicate_metrics"
 }
 
-class EstimateLibraryComplexity(in: PathToBam,
-                                prefix: Option[Path],
+class EstimateLibraryComplexity(override val in: PathToBam,
+                                override val prefix: Option[Path],
                                 var minIdenticalBases: Int = 5,
                                 var numPfReads: Option[Long] = None,
                                 templateUmiTag: Option[String] = None,
                                 read1UmiTag: Option[String] = None,
                                 read2UmiTag: Option[String] = None)
-  extends PicardMetricsTask(in = in, prefix = prefix) {
+  extends PicardTask with PicardMetricsTask {
 
   override def metricsExtension: String = EstimateLibraryComplexity.MetricsExtension
 

--- a/tasks/src/main/scala/dagr/tasks/picard/MarkDuplicates.scala
+++ b/tasks/src/main/scala/dagr/tasks/picard/MarkDuplicates.scala
@@ -36,16 +36,16 @@ object MarkDuplicates {
   val MetricsExtension = ".duplicate_metrics"
 }
 
-class MarkDuplicates(in: PathToBam,
+class MarkDuplicates(override val in: PathToBam,
                      out: Option[PathToBam] = None,
-                     prefix: Option[Path] = None,
+                     override val prefix: Option[Path] = None,
                      comment: Option[String] = None,
                      opticalDuplicatesPixelDistance: Option[Int] = None,
                      assumeSorted: Boolean = true,
                      templateUmiTag: Option[String] = None,
                      read1UmiTag: Option[String] = None,
                      read2UmiTag: Option[String] = None)
-  extends PicardMetricsTask(in = out.getOrElse(in), prefix = prefix) {
+  extends PicardTask with PicardMetricsTask {
   requires(Cores(1), Memory("6G"))
 
   override def metricsExtension: String = MarkDuplicates.MetricsExtension

--- a/tasks/src/main/scala/dagr/tasks/picard/MarkIlluminaAdapters.scala
+++ b/tasks/src/main/scala/dagr/tasks/picard/MarkIlluminaAdapters.scala
@@ -37,12 +37,12 @@ object MarkIlluminaAdapters {
   val MetricsExtension = ".adapter_metrics"
 }
 
-class MarkIlluminaAdapters(in: PathToBam,
+class MarkIlluminaAdapters(override val in: PathToBam,
                            out: PathToBam,
-                           prefix: Option[Path],
+                           override val prefix: Option[Path],
                            fivePrimeAdapter: Option[String] = None,
                            threePrimeAdapter: Option[String] = None)
-  extends PicardMetricsTask(in = out, prefix = prefix) with Pipe[SamOrBam,SamOrBam] {
+  extends PicardTask with PicardMetricsTask with Pipe[SamOrBam,SamOrBam] {
   requires(Cores(1), Memory("1G"))
 
   override def metricsExtension: String = MarkIlluminaAdapters.MetricsExtension

--- a/tasks/src/main/scala/dagr/tasks/picard/PicardMetricsTask.scala
+++ b/tasks/src/main/scala/dagr/tasks/picard/PicardMetricsTask.scala
@@ -35,7 +35,14 @@ object PicardOutput extends Enumeration {
 }
 
 /** Simple trait that requires knowing where a metrics file is for a Picard metric generating tool. */
-abstract class PicardMetricsTask(private val in: PathToBam, private val prefix: Option[Path] = None) extends PicardTask {
+trait PicardMetricsTask {
+
+  /** The path to the input BAM */
+  def in: PathToBam
+
+  /** The optional path to the prefix of the metrics file */
+  def prefix: Option[Path] = None
+
   /** Method that should be used to fetch the file prefix, instead of accessing `prefix` directly. */
   def pathPrefix :PathPrefix = prefix getOrElse PathUtil.removeExtension(in)
 

--- a/tasks/src/main/scala/dagr/tasks/picard/ValidateSamFile.scala
+++ b/tasks/src/main/scala/dagr/tasks/picard/ValidateSamFile.scala
@@ -35,7 +35,10 @@ object ValidateSamFile {
   val MetricsExtension = ".validation_metrics"
 }
 
-class ValidateSamFile(in: PathToBam, prefix: Option[Path], ref: PathToFasta) extends PicardMetricsTask(in = in, prefix = prefix) {
+class ValidateSamFile(override val in: PathToBam,
+                      override val prefix: Option[Path],
+                      ref: PathToFasta)
+  extends PicardTask with PicardMetricsTask {
   // Override the default stringency
   validationStringency = Option(ValidationStringency.STRICT)
 


### PR DESCRIPTION
This allows other tools that produce Picard-like metric files to mix in
the this trait to get all the nice methods for specifying metric files.
