### PR TITLE
Interval lists should be optional for FreeBayes.

### DIFF
--- a/tasks/src/main/scala/dagr/tasks/gatk/GenotypeGvcfs.scala
+++ b/tasks/src/main/scala/dagr/tasks/gatk/GenotypeGvcfs.scala
@@ -31,13 +31,13 @@ import scala.collection.mutable.ListBuffer
 
 object GenotypeGvcfs {
   /** Constructs a GenotypeGvcfs for genotyping multiple samples concurrently. */
-  def apply(ref: PathToFasta, intervals: PathToIntervals, gvcfs: Seq[PathToVcf], vcf: PathToVcf, dbSnpVcf: Option[PathToVcf]) : GenotypeGvcfs = {
-    new GenotypeGvcfs(ref, Some(intervals), gvcfs, vcf, dbSnpVcf)
+  def apply(ref: PathToFasta, intervals: Option[PathToIntervals], gvcfs: Seq[PathToVcf], vcf: PathToVcf, dbSnpVcf: Option[PathToVcf]) : GenotypeGvcfs = {
+    new GenotypeGvcfs(ref, intervals, gvcfs, vcf, dbSnpVcf)
   }
 
   /** Constructs a GenotypeGvcfs for genotyping a single sample. */
-  def apply(ref: PathToFasta, intervals: PathToIntervals, gvcf: PathToVcf, vcf: PathToVcf, dbSnpVcf: Option[PathToVcf]) : GenotypeGvcfs = {
-    new GenotypeGvcfs(ref, Some(intervals), Seq(gvcf), vcf, dbSnpVcf)
+  def apply(ref: PathToFasta, intervals: Option[PathToIntervals], gvcf: PathToVcf, vcf: PathToVcf, dbSnpVcf: Option[PathToVcf]) : GenotypeGvcfs = {
+    new GenotypeGvcfs(ref, intervals, Seq(gvcf), vcf, dbSnpVcf)
   }
 }
 

--- a/tasks/src/main/scala/dagr/tasks/gatk/HaplotypeCaller.scala
+++ b/tasks/src/main/scala/dagr/tasks/gatk/HaplotypeCaller.scala
@@ -32,14 +32,14 @@ import scala.collection.mutable.ListBuffer
   * Runs the GATK haplotype caller i GVCF mode on a single sample.
   */
 class HaplotypeCaller(ref: PathToFasta,
-                      intervals: PathToIntervals,
+                      intervals: Option[PathToIntervals],
                       val bam: PathToBam,
                       val vcf: PathToVcf,
                       val maxAlternateAlleles: Int = 3,
                       val contaminationFraction: Double = 0.0,
                       val rnaMode: Boolean = false
                       )
- extends GatkTask("HaplotypeCaller", ref, intervals=Some(intervals)) {
+ extends GatkTask("HaplotypeCaller", ref, intervals=intervals) {
 
   override protected def addWalkerArgs(buffer: ListBuffer[Any]): Unit = {
     buffer.append("--minPruning", "3")


### PR DESCRIPTION
This enables whole genome variant calling for FreeBayes.
