### PR TITLE
Improvements to FreeBayes Germline calling.

### DIFF
--- a/core/src/main/scala/dagr/core/execsystem/Resource.scala
+++ b/core/src/main/scala/dagr/core/execsystem/Resource.scala
@@ -160,4 +160,6 @@ case class Cores(override val value: Double) extends Resource[Double, Cores](val
 /** Companion object for Core adding an additional apply() method. */
 object Cores {
   def apply(cores: Cores): Cores = new Cores(cores.value)
+  val none = Cores(0.0)
+  val infinite = Cores(Double.MaxValue) // Not really infinite, but close to it.
 }

--- a/core/src/main/scala/dagr/core/execsystem/ResourceSet.scala
+++ b/core/src/main/scala/dagr/core/execsystem/ResourceSet.scala
@@ -35,7 +35,7 @@ object ResourceSet {
 case class ResourceSet(cores: Cores = Cores(0), memory: Memory = Memory(0)) {
   def isEmpty: Boolean = cores.value == 0 && memory.value == 0
 
-  override def toString: String = s"memory=${memory.value}, cores=${cores.value}"
+  override def toString: String = s"memory=${memory.prettyString}, cores=${cores.value}"
 
   /** Returns true if `subset` is a subset of this resource set and false otherwise. */
   private def subsettable(subset: ResourceSet) = subset.cores <= this.cores && subset.memory <= this.memory

--- a/core/src/main/scala/dagr/core/execsystem/ResourceSet.scala
+++ b/core/src/main/scala/dagr/core/execsystem/ResourceSet.scala
@@ -32,10 +32,10 @@ object ResourceSet {
 }
 
 /** Holds information about a set of resources */
-case class ResourceSet(cores: Cores = Cores(0), memory: Memory = Memory(0)) {
+case class ResourceSet(cores: Cores = Cores.none, memory: Memory = Memory.none) {
   def isEmpty: Boolean = cores.value == 0 && memory.value == 0
 
-  override def toString: String = s"memory=${memory.prettyString}, cores=${cores.value}"
+  override def toString: String = s"memory=$memory, cores=${cores.value}"
 
   /** Returns true if `subset` is a subset of this resource set and false otherwise. */
   private def subsettable(subset: ResourceSet) = subset.cores <= this.cores && subset.memory <= this.memory

--- a/core/src/main/scala/dagr/core/execsystem/TaskManager.scala
+++ b/core/src/main/scala/dagr/core/execsystem/TaskManager.scala
@@ -28,7 +28,7 @@ import java.time.Instant
 
 import dagr.core.DagrDef._
 import dagr.commons.util.LazyLogging
-import dagr.core.tasksystem.{Retry, Task, UnitTask}
+import dagr.core.tasksystem._
 import dagr.commons.util.BiMap
 import dagr.commons.io.{Io, PathUtil}
 
@@ -537,7 +537,13 @@ class TaskManager(taskManagerResources: SystemResources = TaskManagerDefaults.de
       if (!allDone && runningTasks.isEmpty && tasksToSchedule.isEmpty) {
         logger.error("No running tasks and no tasks scheduled but had " + readyTasks.size + " tasks ready to be scheduled")
         readyTasks.foreach(readyTask => {
-          logger.error(readyTask.toString + " tasks status: " + taskStatusFor(readyTask) + " graph state: " + graphNodeStateFor(readyTask))
+          val resources = readyTask match {
+            case t: FixedResources    => "Fixed Resources: " + t.resources
+            case t: VariableResources => "Variable Resources: " + t.resources
+            case t: Schedulable       => "Schedulable Resources: " + t.pickResources(new ResourceSet(Cores(Integer.MAX_VALUE), Memory.infinite)).getOrElse("Unknown Resources")
+            case t                    => "Unknown Resources"
+          }
+          logger.error(readyTask.toString + " tasks status: " + taskStatusFor(readyTask) + " graph state: " + graphNodeStateFor(readyTask) + " resources: " + resources)
         })
         allDone = true
       }

--- a/core/src/main/scala/dagr/core/tasksystem/Linker.scala
+++ b/core/src/main/scala/dagr/core/tasksystem/Linker.scala
@@ -35,9 +35,9 @@ object Linker {
     * method, passing it the `parent` and `child`, after the `parent` has successfully
     * executed and before the `child` is executed.
     *
-    * @param parent a task that produces some information on which the child depends
-    * @param child  a task which needs to receive some information from the parent task
-    * @param link   a method that will receive be invoked with a reference to both tasks
+    * @param from a task that produces some information on which the child depends
+    * @param to a task which needs to receive some information from the parent task
+    * @param link a method that will receive be invoked with a reference to both tasks
     *               at the appropriate time during pipeline execution
     * @tparam From the type of the parent task (usually inferred)
     * @tparam To  the type of the child task (usually inferred)
@@ -48,7 +48,7 @@ object Linker {
 
     val linker = SimpleInJvmTask(link(from, to))
     linker.name = "LinkerFrom" + from.name + "To" + to.name
-    linker.requires(Cores(0), Memory(0))
+    linker.requires(Cores.none, Memory.none)
     from ==> linker ==> to
     linker
   }

--- a/core/src/main/scala/dagr/core/tasksystem/Pipe.scala
+++ b/core/src/main/scala/dagr/core/tasksystem/Pipe.scala
@@ -80,6 +80,13 @@ trait Pipe[In,Out] extends ProcessTask {
   private[tasksystem] def ordered: Seq[Pipe[_,_]] = Seq[Pipe[_,_]](this)
 }
 
+/** A trait for pipe tasks that consumes no cores and no memory */
+trait PipeWithNoResources[In,Out] extends Pipe[In,Out] with FixedResources {
+  val memory: Memory = Memory.none
+  val cores: Cores = Cores(0.0)
+  this.requires(cores, memory)
+}
+
 /** A simplified trait for sink tasks that can receive data via a pipe, but cannot pipe onwards. */
 trait PipeIn[In] extends Pipe[In,Void]
 

--- a/core/src/main/scala/dagr/core/tasksystem/ProcessTask.scala
+++ b/core/src/main/scala/dagr/core/tasksystem/ProcessTask.scala
@@ -57,12 +57,15 @@ trait ProcessTask extends UnitTask {
     */
   def args: Seq[Any]
 
+  protected var quoteIfNecessary: Boolean = true
+
   /** Returns a string representation of the command to be run by this task.
     *
     * @return the command string.
     */
   private[core] def commandLine: String = {
-    args.map(arg => ProcessTask.quoteIfNecessary(arg.toString)).mkString(" ")
+    if (quoteIfNecessary) args.map(arg => ProcessTask.quoteIfNecessary(arg.toString)).mkString(" ")
+    else args.mkString(" ")
   }
 
   /** Write the command to the script and get a process to run.

--- a/core/src/main/scala/dagr/core/tasksystem/Schedulable.scala
+++ b/core/src/main/scala/dagr/core/tasksystem/Schedulable.scala
@@ -75,7 +75,7 @@ trait FixedResources extends ScheduleWithEmptyDefaultResources {
   }
 
   /** Sets the resources that are required by this task, overriding all previous values. */
-  def requires(cores: Cores = Cores(0), memory: Memory = Memory(0)) : this.type = requires(ResourceSet(cores, memory))
+  def requires(cores: Cores = Cores.none, memory: Memory = Memory.none) : this.type = requires(ResourceSet(cores, memory))
 
   /** Sets the resources that are required by this task, overriding all previous values. */
   def requires(cores: Double, memory: String) : this.type = { requires(Cores(cores), Memory(memory)) }

--- a/core/src/main/scala/dagr/core/tasksystem/ShellCommand.scala
+++ b/core/src/main/scala/dagr/core/tasksystem/ShellCommand.scala
@@ -36,19 +36,8 @@ object ShellCommand {
   * Executes a command, with a set of arguments, in a shell.
   */
 class ShellCommand(val commands: String*) extends ProcessTask with FixedResources {
-
   requires(Cores(1), Memory("32M"))
   if (commands.isEmpty) throw new IllegalArgumentException("No commands to ShellCommand")
 
   override def args: Seq[Any] = commands
-
-}
-
-/**
-  * Executes a command, with a set of arguments, in a shell.  Arguments with special characters
-  * or otherwise will be modified (quoted, escaped, etc.).  This may be dangerous depending on
-  * the commands given.  In general, use `ShellCommand` if you are not 100% sure.
-  */
-class ShellCommandAsIs(commands: String*) extends ShellCommand(commands:_*) {
-  this.quoteIfNecessary = false
 }

--- a/core/src/test/scala/dagr/core/execsystem/NaiveSchedulerTest.scala
+++ b/core/src/test/scala/dagr/core/execsystem/NaiveSchedulerTest.scala
@@ -48,7 +48,7 @@ class NaiveSchedulerTest extends UnitSpec with LazyLogging {
 
   it should "accept a simple task with no resources when the system has no resources" in {
     val task: UnitTask = new NoOpTask withName "simple" requires ResourceSet.empty
-    scheduler.schedule(List(task), Cores(0), Memory(0), Memory(0)) should contain key task
+    scheduler.schedule(List(task), Cores.none, Memory.none, Memory.none) should contain key task
   }
 
   it should "reject a task for too much memory" in {
@@ -97,7 +97,7 @@ class NaiveSchedulerTest extends UnitSpec with LazyLogging {
   it should "accept two simple tasks with no resources with no system resources" in {
     val taskOne: UnitTask = new NoOpTask withName "simple" requires ResourceSet.empty
     val taskTwo: UnitTask = new NoOpTask withName "simple" requires ResourceSet.empty
-    val tasks: Map[UnitTask, ResourceSet] = scheduler.schedule(List(taskOne, taskTwo), Cores(0), Memory(0), Memory(0))
+    val tasks: Map[UnitTask, ResourceSet] = scheduler.schedule(List(taskOne, taskTwo), Cores.none, Memory.none, Memory.none)
     tasks should contain key taskOne
     tasks should contain key taskTwo
     tasks should have size 2
@@ -115,7 +115,7 @@ class NaiveSchedulerTest extends UnitSpec with LazyLogging {
   it should "accept only tasks with no resources set when there are no system resources" in {
     val taskOne: UnitTask = new NoOpTask withName "taskOne" requires(Cores(1), Memory("1G"))
     val taskTwo: UnitTask = new NoOpTask withName "taskTwo" requires ResourceSet.empty
-    val tasks: Map[UnitTask, ResourceSet] = scheduler.schedule(List(taskOne, taskTwo), Cores(0), Memory(0), Memory(0))
+    val tasks: Map[UnitTask, ResourceSet] = scheduler.schedule(List(taskOne, taskTwo), Cores.none, Memory.none, Memory.none)
     tasks should have size 1
     tasks should contain key taskTwo
   }
@@ -134,17 +134,17 @@ class NaiveSchedulerTest extends UnitSpec with LazyLogging {
     }
 
     // Should schedule with 32M
-    var scheduledTasksAndResources = scheduler.schedule(readyTasks = List(task), Cores(2), Memory(0), Memory("32M"))
+    var scheduledTasksAndResources = scheduler.schedule(readyTasks = List(task), Cores(2), Memory.none, Memory("32M"))
     scheduledTasksAndResources should contain key task
     scheduledTasksAndResources should contain value ResourceSet(Cores(1), Memory("32M"))
 
     // Should schedule with 16M
-    scheduledTasksAndResources = scheduler.schedule(readyTasks = List(task), Cores(2), Memory(0), Memory("16M"))
+    scheduledTasksAndResources = scheduler.schedule(readyTasks = List(task), Cores(2), Memory.none, Memory("16M"))
     scheduledTasksAndResources should contain key task
     scheduledTasksAndResources should contain value ResourceSet(Cores(1), Memory("16M"))
 
     // Should not schedule
-    scheduledTasksAndResources = scheduler.schedule(readyTasks = List(task), Cores(2), Memory(0), Memory("8M"))
+    scheduledTasksAndResources = scheduler.schedule(readyTasks = List(task), Cores(2), Memory.none, Memory("8M"))
     scheduledTasksAndResources should not contain key(task)
     scheduledTasksAndResources should have size 0
   }
@@ -173,7 +173,7 @@ class NaiveSchedulerTest extends UnitSpec with LazyLogging {
     val scheduler = new NaiveScheduler()
     val systemCores: Cores = Cores(4)
     val systemMemory: Memory = Memory("4G")
-    val jvmMemory: Memory = Memory(0)
+    val jvmMemory: Memory = Memory.none
 
     // A task that would like 1-8 cores each
     class HungryTask extends ProcessTask {

--- a/core/src/test/scala/dagr/core/execsystem/ResourceTest.scala
+++ b/core/src/test/scala/dagr/core/execsystem/ResourceTest.scala
@@ -71,7 +71,7 @@ class ResourceTest extends UnitSpec {
   }
 
   "Resource" should "add, subtract, and compare resources" in {
-    val low = Memory(0)
+    val low = Memory.none
     val mid = Memory(10)
     val high = Memory(20)
 
@@ -117,7 +117,7 @@ class ResourceTest extends UnitSpec {
 
   it should "always give back the numeric value via toString for easy arg usage" in {
     Cores(7).toString shouldBe "7.0"
-    Cores(0).toString shouldBe "0.0"
+    Cores.none.toString shouldBe "0.0"
     Cores(5000).toString shouldBe "5000.0"
     Memory(1024).toString shouldBe "1024"
     Memory("1G").toString shouldBe (1024*1024*1024).toString

--- a/tasks/src/main/scala/dagr/tasks/misc/GetSampleNamesFromVcf.scala
+++ b/tasks/src/main/scala/dagr/tasks/misc/GetSampleNamesFromVcf.scala
@@ -36,6 +36,7 @@ import scala.collection.mutable.ListBuffer
 
 /** Gets the sample names from a VCF */
 class GetSampleNamesFromVcf(val vcf: PathToVcf) extends SimpleInJvmTask {
+  name = "GetSampleNamesFromVcf"
   private val _sampleNames: mutable.ListBuffer[String] = new ListBuffer[String]()
   def sampleNames: List[String] = this._sampleNames.toList
 

--- a/tasks/src/main/scala/dagr/tasks/picard/UpdateVcfSequenceDictionary.scala
+++ b/tasks/src/main/scala/dagr/tasks/picard/UpdateVcfSequenceDictionary.scala
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2015 Fulcrum Genomics LLC
+ * Copyright (c) 2016 Fulcrum Genomics LLC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,34 +21,19 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package dagr.core.tasksystem
 
-import dagr.core.execsystem.{Cores, Memory}
+package dagr.tasks.picard
 
-/** Companion object to provide a couple of helper constructors for ShellCommand. */
-object ShellCommand {
-  /** Constructs a Shell Command using varargs. */
-  def apply(args: Any*) : ShellCommand = new ShellCommand(args.map(_.toString):_*)
+import dagr.core.tasksystem.Pipe
+import dagr.tasks.DagrDef._
+import dagr.tasks.DataTypes.Vcf
 
-}
+import scala.collection.mutable.ListBuffer
 
-/**
-  * Executes a command, with a set of arguments, in a shell.
-  */
-class ShellCommand(val commands: String*) extends ProcessTask with FixedResources {
-
-  requires(Cores(1), Memory("32M"))
-  if (commands.isEmpty) throw new IllegalArgumentException("No commands to ShellCommand")
-
-  override def args: Seq[Any] = commands
-
-}
-
-/**
-  * Executes a command, with a set of arguments, in a shell.  Arguments with special characters
-  * or otherwise will be modified (quoted, escaped, etc.).  This may be dangerous depending on
-  * the commands given.  In general, use `ShellCommand` if you are not 100% sure.
-  */
-class ShellCommandAsIs(commands: String*) extends ShellCommand(commands:_*) {
-  this.quoteIfNecessary = false
+class UpdateVcfSequenceDictionary(val in: PathToVcf, val out: PathToVcf, val dict: FilePath) extends PicardTask with Pipe[Vcf,Vcf] {
+  override protected def addPicardArgs(buffer: ListBuffer[Any]): Unit = {
+    buffer += "I=" + in
+    buffer += "O=" + out
+    buffer += "SD=" + dict
+  }
 }

--- a/tasks/src/main/scala/dagr/tasks/vc/FilterFreeBayesCalls.scala
+++ b/tasks/src/main/scala/dagr/tasks/vc/FilterFreeBayesCalls.scala
@@ -86,39 +86,39 @@ class FilterFreeBayesCalls(val in: PathToVcf,
     }
 
     // De-compress the input VCF
-    val decompressVcf = new ShellCommand(configureExecutableFromBinDirectory(BgzipBinConfigKey, "bgzip").toString, "-c", "-d", in.toAbsolutePath.toString) with Pipe[Nothing, Vcf]
+    val decompressVcf = new ShellCommand(configureExecutableFromBinDirectory(BgzipBinConfigKey, "bgzip").toString, "-c", "-d", in.toAbsolutePath.toString) with PipeWithNoResources[Nothing, Vcf]
 
     // Remove low quality calls
-    val filterLowQualityCalls = new ShellCommandAsIs(configureExecutableFromBinDirectory(BcfToolsBinConfigKey, "bcftools").toString, "filter", "-i", """'ALT="<*>" || QUAL > 5'""", "2>", "/dev/null") with Pipe[Vcf, Vcf]
+    val filterLowQualityCalls = new ShellCommandAsIs(configureExecutableFromBinDirectory(BcfToolsBinConfigKey, "bcftools").toString, "filter", "-i", """'ALT="<*>" || QUAL > 5'""", "2>", "/dev/null") with PipeWithNoResources[Vcf, Vcf]
 
     // fix ambiguous (IUPAC) reference base calls
-    val fixAmbiguousIupacReferenceCalls = new ShellCommandAsIs("""awk -F$'\t' -v OFS='\t' '{if ($0 !~ /^#/) gsub(/[KMRYSWBVHDX]/, "N", $4) } { print }'""") with Pipe[Vcf, Vcf]
+    val fixAmbiguousIupacReferenceCalls = new ShellCommandAsIs("""awk -F$'\t' -v OFS='\t' '{if ($0 !~ /^#/) gsub(/[KMRYSWBVHDX]/, "N", $4) } { print }'""") with PipeWithNoResources[Vcf, Vcf]
 
     // remove alternate alleles that are not called in any sample
-    val removeAlts = new ShellCommandAsIs(configureExecutableFromBinDirectory(BcfToolsBinConfigKey, "bcftools").toString, "view", "-a", "-", "2>", "/dev/null") with Pipe[Vcf, Vcf]
+    val removeAlts = new ShellCommandAsIs(configureExecutableFromBinDirectory(BcfToolsBinConfigKey, "bcftools").toString, "view", "-a", "-", "2>", "/dev/null") with PipeWithNoResources[Vcf, Vcf]
 
     // remove calls with missing alternative alleles
     // source: https://github.com/chapmanb/bcbio-nextgen/blob/60a0f3c4f8ec658f8c34d6bc77b23a90f47b45d6/bcbio/variation/freebayes.py#L237
-    val removeMissingAlts = new ShellCommandAsIs("""awk -F$'\t' -v OFS='\t' '{if ($0 ~ /^#/ || $4 != ".") { print } }'""") with Pipe[Vcf, Vcf]
+    val removeMissingAlts = new ShellCommandAsIs("""awk -F$'\t' -v OFS='\t' '{if ($0 ~ /^#/ || $4 != ".") { print } }'""") with PipeWithNoResources[Vcf, Vcf]
 
     // split MNP variants into multiple records
-    val splitMnpVariants = new ShellCommand(configureExecutableFromBinDirectory(VcfLibBinConfigKey, "vcfallelicprimitives").toString, "-t", "DECOMPOSED", "--keep-geno") with Pipe[Vcf, Vcf]
+    val splitMnpVariants = new ShellCommand(configureExecutableFromBinDirectory(VcfLibBinConfigKey, "vcfallelicprimitives").toString, "-t", "DECOMPOSED", "--keep-geno") with PipeWithNoResources[Vcf, Vcf]
 
     // update AC and NS
-    val updateAcAndNs = new ShellCommand(configureExecutableFromBinDirectory(VcfLibBinConfigKey, "vcffixup").toString) with Pipe[Vcf, Vcf]
+    val updateAcAndNs = new ShellCommand(configureExecutableFromBinDirectory(VcfLibBinConfigKey, "vcffixup").toString) with PipeWithNoResources[Vcf, Vcf]
 
     // sort records using a fixed length window
-    val sortVcf = new ShellCommand(configureExecutableFromBinDirectory(VcfLibBinConfigKey, "vcfstreamsort").toString) with Pipe[Vcf, Vcf]
+    val sortVcf = new ShellCommand(configureExecutableFromBinDirectory(VcfLibBinConfigKey, "vcfstreamsort").toString) with PipeWithNoResources[Vcf, Vcf]
 
     // standardizes the representation of variants using parsimony and left-alignment relative to the reference genome
     // See: http://genome.sph.umich.edu/wiki/Variant_Normalization
-    val leftAlign = new ShellCommandAsIs(configureExecutableFromBinDirectory(VtBinConfigKey, "vt").toString, "normalize", "-n", "-r", ref.toAbsolutePath.toString, "-q", "-", "2> /dev/null") with Pipe[Vcf, Vcf]
+    val leftAlign = new ShellCommandAsIs(configureExecutableFromBinDirectory(VtBinConfigKey, "vt").toString, "normalize", "-n", "-r", ref.toAbsolutePath.toString, "-q", "-", "2> /dev/null") with PipeWithNoResources[Vcf, Vcf]
 
     // remove both duplicate and reference alternate alleles
-    val removeDuplicateAlleles = new ShellCommand(configureExecutableFromBinDirectory(VcfLibBinConfigKey, "vcfuniqalleles").toString) with Pipe[Vcf, Vcf]
+    val removeDuplicateAlleles = new ShellCommand(configureExecutableFromBinDirectory(VcfLibBinConfigKey, "vcfuniqalleles").toString) with PipeWithNoResources[Vcf, Vcf]
 
     // compress the output (or not)
-    val compressOutput = if (compress) new ShellCommand(configureExecutableFromBinDirectory(BgzipBinConfigKey, "bgzip").toString, "-c") with Pipe[Vcf,Vcf] else Pipes.empty[Vcf]
+    val compressOutput = if (compress) new ShellCommand(configureExecutableFromBinDirectory(BgzipBinConfigKey, "bgzip").toString, "-c") with PipeWithNoResources[Vcf,Vcf] else Pipes.empty[Vcf]
 
     List(decompressVcf | filterLowQualityCalls | fixAmbiguousIupacReferenceCalls | removeAlts | removeMissingAlts | splitMnpVariants | updateAcAndNs |sortVcf | leftAlign | removeDuplicateAlleles | compressOutput > out)
   }

--- a/tasks/src/main/scala/dagr/tasks/vc/FilterFreeBayesCalls.scala
+++ b/tasks/src/main/scala/dagr/tasks/vc/FilterFreeBayesCalls.scala
@@ -120,6 +120,8 @@ class FilterFreeBayesCalls(val in: PathToVcf,
     // compress the output (or not)
     val compressOutput = if (compress) new ShellCommand(configureExecutableFromBinDirectory(BgzipBinConfigKey, "bgzip").toString, "-c") with PipeWithNoResources[Vcf,Vcf] else Pipes.empty[Vcf]
 
-    List(decompressVcf | filterLowQualityCalls | fixAmbiguousIupacReferenceCalls | removeAlts | removeMissingAlts | splitMnpVariants | updateAcAndNs |sortVcf | leftAlign | removeDuplicateAlleles | compressOutput > out)
+    val pipeChain = decompressVcf | filterLowQualityCalls | fixAmbiguousIupacReferenceCalls | removeAlts | removeMissingAlts | splitMnpVariants | updateAcAndNs |sortVcf | leftAlign | removeDuplicateAlleles | compressOutput > out
+
+    List(pipeChain withName (this.name + "PipeChain"))
   }
 }

--- a/tasks/src/main/scala/dagr/tasks/vc/FilterFreeBayesCalls.scala
+++ b/tasks/src/main/scala/dagr/tasks/vc/FilterFreeBayesCalls.scala
@@ -25,11 +25,11 @@
 package dagr.tasks.vc
 
 import dagr.core.config.Configuration
-import dagr.core.tasksystem.{FixedResources, ProcessTask}
+import dagr.core.execsystem.ResourceSet
+import dagr.core.tasksystem._
 import dagr.tasks.DagrDef
-import DagrDef._
-
-import scala.collection.mutable.ListBuffer
+import dagr.tasks.DagrDef._
+import dagr.tasks.DataTypes._
 
 object FilterFreeBayesCalls {
 
@@ -37,8 +37,6 @@ object FilterFreeBayesCalls {
   val VtBinConfigKey       = "vt.bin"
   val BcfToolsBinConfigKey = "bcftools.bin"
   val BgzipBinConfigKey    = "bgzip.bin"
-
-  protected val PipeArg = "\\\n  |"
 }
 
 /** Applies various filters and ensures proper VCF formatting for variants produced by FreeBayes.
@@ -73,59 +71,55 @@ class FilterFreeBayesCalls(val in: PathToVcf,
                            val somatic: Boolean = false,
                            val minQual: Int = 5
                           )
-  extends ProcessTask with Configuration with FixedResources {
+  extends Task with Configuration with FixedResources {
   import FilterFreeBayesCalls._
 
   requires(1.0, "2G")
 
-  override def args: Seq[Any] = {
-    val buffer = ListBuffer[Any]()
+  override def applyResources(resources: ResourceSet): Unit = Unit
 
-    // De-compress the input VCF
-    buffer.append(configureExecutableFromBinDirectory(BgzipBinConfigKey, "bgzip"), "-c", "-d", in)
-
-    // Remove low quality calls
-    buffer.append(PipeArg, configureExecutableFromBinDirectory(VcfLibBinConfigKey, "vcffilter"), "-f", s"'QUAL > $minQual'", "-s")
-
+  override def getTasks: Traversable[_ <: Task] = {
     // Apply filters specific to somatic calling
     if (somatic) {
       // source: https://github.com/chapmanb/bcbio-nextgen/blob/60a0f3c4f8ec658f8c34d6bc77b23a90f47b45d6/bcbio/variation/freebayes.py#L250
-      // TODO
       logger.warning("bcbio filtering, for example, adding REJECTS or SOMATIC flags, has not been implemented.  Contact your nearest developer.")
     }
 
+    // De-compress the input VCF
+    val decompressVcf = new ShellCommand(configureExecutableFromBinDirectory(BgzipBinConfigKey, "bgzip").toString, "-c", "-d", in.toAbsolutePath.toString) with Pipe[Nothing, Vcf]
+
+    // Remove low quality calls
+    val filterLowQualityCalls = new ShellCommandAsIs(configureExecutableFromBinDirectory(BcfToolsBinConfigKey, "bcftools").toString, "filter", "-i", """'ALT="<*>" || QUAL > 5'""", "2>", "/dev/null") with Pipe[Vcf, Vcf]
+
     // fix ambiguous (IUPAC) reference base calls
-    // source: https://github.com/chapmanb/bcbio-nextgen/blob/e4d520b23a4868b8d92f83a3bc0ac11894cd2dbc/bcbio/variation/vcfutils.py#L86
-    buffer.append(PipeArg, """awk -F$'\t' -v OFS='\t' '{if ($0 !~ /^#/) gsub(/[KMRYSWBVHDX]/, "N", $4) } { print }'""")
+    val fixAmbiguousIupacReferenceCalls = new ShellCommandAsIs("""awk -F$'\t' -v OFS='\t' '{if ($0 !~ /^#/) gsub(/[KMRYSWBVHDX]/, "N", $4) } { print }'""") with Pipe[Vcf, Vcf]
 
     // remove alternate alleles that are not called in any sample
-    buffer.append(PipeArg, configureExecutableFromBinDirectory(BcfToolsBinConfigKey, "bcftools"), "view", "-a", "-", "2> /dev/null")
+    val removeAlts = new ShellCommandAsIs(configureExecutableFromBinDirectory(BcfToolsBinConfigKey, "bcftools").toString, "view", "-a", "-", "2>", "/dev/null") with Pipe[Vcf, Vcf]
 
     // remove calls with missing alternative alleles
     // source: https://github.com/chapmanb/bcbio-nextgen/blob/60a0f3c4f8ec658f8c34d6bc77b23a90f47b45d6/bcbio/variation/freebayes.py#L237
-    buffer.append(PipeArg, """awk -F$'\t' -v OFS='\t' '{if ($0 ~ /^#/ || $4 != ".") { print } }'""")
-
+    val removeMissingAlts = new ShellCommandAsIs("""awk -F$'\t' -v OFS='\t' '{if ($0 ~ /^#/ || $4 != ".") { print } }'""") with Pipe[Vcf, Vcf]
 
     // split MNP variants into multiple records
-    buffer.append(PipeArg, configureExecutableFromBinDirectory(VcfLibBinConfigKey, "vcfallelicprimitives"), "--keep-geno")
+    val splitMnpVariants = new ShellCommand(configureExecutableFromBinDirectory(VcfLibBinConfigKey, "vcfallelicprimitives").toString, "-t", "DECOMPOSED", "--keep-geno") with Pipe[Vcf, Vcf]
 
     // update AC and NS
-    buffer.append(PipeArg, configureExecutableFromBinDirectory(VcfLibBinConfigKey, "vcffixup"), "-")
+    val updateAcAndNs = new ShellCommand(configureExecutableFromBinDirectory(VcfLibBinConfigKey, "vcffixup").toString) with Pipe[Vcf, Vcf]
 
     // sort records using a fixed length window
-    buffer.append(PipeArg, configureExecutableFromBinDirectory(VcfLibBinConfigKey, "vcfstreamsort"))
+    val sortVcf = new ShellCommand(configureExecutableFromBinDirectory(VcfLibBinConfigKey, "vcfstreamsort").toString) with Pipe[Vcf, Vcf]
 
     // standardizes the representation of variants using parsimony and left-alignment relative to the reference genome
     // See: http://genome.sph.umich.edu/wiki/Variant_Normalization
-    buffer.append(PipeArg, configureExecutableFromBinDirectory(VtBinConfigKey,     "vt"), "normalize", "-n", "-r", ref, "-q", "-", "2> /dev/null")
+    val leftAlign = new ShellCommandAsIs(configureExecutableFromBinDirectory(VtBinConfigKey, "vt").toString, "normalize", "-n", "-r", ref.toAbsolutePath.toString, "-q", "-", "2> /dev/null") with Pipe[Vcf, Vcf]
 
     // remove both duplicate and reference alternate alleles
-    buffer.append(PipeArg, configureExecutableFromBinDirectory(VcfLibBinConfigKey, "vcfuniqalleles"))
+    val removeDuplicateAlleles = new ShellCommand(configureExecutableFromBinDirectory(VcfLibBinConfigKey, "vcfuniqalleles").toString) with Pipe[Vcf, Vcf]
 
-    // Output it
-    if (compress) buffer.append(PipeArg, configureExecutableFromBinDirectory(BgzipBinConfigKey, "bgzip"), "-c")
-    buffer.append(">", out)
+    // compress the output (or not)
+    val compressOutput = if (compress) new ShellCommand(configureExecutableFromBinDirectory(BgzipBinConfigKey, "bgzip").toString, "-c") with Pipe[Vcf,Vcf] else Pipes.empty[Vcf]
 
-    buffer
+    List(decompressVcf | filterLowQualityCalls | fixAmbiguousIupacReferenceCalls | removeAlts | removeMissingAlts | splitMnpVariants | updateAcAndNs |sortVcf | leftAlign | removeDuplicateAlleles | compressOutput > out)
   }
 }

--- a/tasks/src/main/scala/dagr/tasks/vc/FilterFreeBayesCalls.scala
+++ b/tasks/src/main/scala/dagr/tasks/vc/FilterFreeBayesCalls.scala
@@ -26,8 +26,8 @@ package dagr.tasks.vc
 
 import dagr.core.config.Configuration
 import dagr.core.execsystem.ResourceSet
+import dagr.core.tasksystem.Pipes.PipeWithNoResources
 import dagr.core.tasksystem._
-import dagr.tasks.DagrDef
 import dagr.tasks.DagrDef._
 import dagr.tasks.DataTypes._
 
@@ -89,17 +89,17 @@ class FilterFreeBayesCalls(val in: PathToVcf,
     val decompressVcf = new ShellCommand(configureExecutableFromBinDirectory(BgzipBinConfigKey, "bgzip").toString, "-c", "-d", in.toAbsolutePath.toString) with PipeWithNoResources[Nothing, Vcf]
 
     // Remove low quality calls
-    val filterLowQualityCalls = new ShellCommandAsIs(configureExecutableFromBinDirectory(BcfToolsBinConfigKey, "bcftools").toString, "filter", "-i", """'ALT="<*>" || QUAL > 5'""", "2>", "/dev/null") with PipeWithNoResources[Vcf, Vcf]
+    val filterLowQualityCalls = new ShellCommand(configureExecutableFromBinDirectory(BcfToolsBinConfigKey, "bcftools").toString, "filter", "-i", """'ALT="<*>" || QUAL > 5'""") with PipeWithNoResources[Vcf, Vcf] discardError()
 
     // fix ambiguous (IUPAC) reference base calls
-    val fixAmbiguousIupacReferenceCalls = new ShellCommandAsIs("""awk -F$'\t' -v OFS='\t' '{if ($0 !~ /^#/) gsub(/[KMRYSWBVHDX]/, "N", $4) } { print }'""") with PipeWithNoResources[Vcf, Vcf]
+    val fixAmbiguousIupacReferenceCalls = new ShellCommand("awk", """-F\t""",  "-v", """OFS=\t""",  """{if ($0 !~ /^#/) gsub(/[KMRYSWBVHDX]/, "N", $4) } { print }""") with PipeWithNoResources[Vcf, Vcf]
 
     // remove alternate alleles that are not called in any sample
-    val removeAlts = new ShellCommandAsIs(configureExecutableFromBinDirectory(BcfToolsBinConfigKey, "bcftools").toString, "view", "-a", "-", "2>", "/dev/null") with PipeWithNoResources[Vcf, Vcf]
+    val removeAlts = new ShellCommand(configureExecutableFromBinDirectory(BcfToolsBinConfigKey, "bcftools").toString, "view", "-a", "-") with PipeWithNoResources[Vcf, Vcf] discardError()
 
     // remove calls with missing alternative alleles
     // source: https://github.com/chapmanb/bcbio-nextgen/blob/60a0f3c4f8ec658f8c34d6bc77b23a90f47b45d6/bcbio/variation/freebayes.py#L237
-    val removeMissingAlts = new ShellCommandAsIs("""awk -F$'\t' -v OFS='\t' '{if ($0 ~ /^#/ || $4 != ".") { print } }'""") with PipeWithNoResources[Vcf, Vcf]
+    val removeMissingAlts = new ShellCommand("awk", """-F\t""", "-v", """OFS=\t""", """{if ($0 ~ /^#/ || $4 != ".") { print } }""") with PipeWithNoResources[Vcf, Vcf]
 
     // split MNP variants into multiple records
     val splitMnpVariants = new ShellCommand(configureExecutableFromBinDirectory(VcfLibBinConfigKey, "vcfallelicprimitives").toString, "-t", "DECOMPOSED", "--keep-geno") with PipeWithNoResources[Vcf, Vcf]
@@ -112,7 +112,7 @@ class FilterFreeBayesCalls(val in: PathToVcf,
 
     // standardizes the representation of variants using parsimony and left-alignment relative to the reference genome
     // See: http://genome.sph.umich.edu/wiki/Variant_Normalization
-    val leftAlign = new ShellCommandAsIs(configureExecutableFromBinDirectory(VtBinConfigKey, "vt").toString, "normalize", "-n", "-r", ref.toAbsolutePath.toString, "-q", "-", "2> /dev/null") with PipeWithNoResources[Vcf, Vcf]
+    val leftAlign = new ShellCommand(configureExecutableFromBinDirectory(VtBinConfigKey, "vt").toString, "normalize", "-n", "-r", ref.toAbsolutePath.toString, "-q", "-") with PipeWithNoResources[Vcf, Vcf] discardError()
 
     // remove both duplicate and reference alternate alleles
     val removeDuplicateAlleles = new ShellCommand(configureExecutableFromBinDirectory(VcfLibBinConfigKey, "vcfuniqalleles").toString) with PipeWithNoResources[Vcf, Vcf]

--- a/tasks/src/main/scala/dagr/tasks/vc/FreeBayes.scala
+++ b/tasks/src/main/scala/dagr/tasks/vc/FreeBayes.scala
@@ -152,7 +152,7 @@ abstract class FreeBayes(val ref: PathToFasta,
     // Generates the regions on the fly
     val generateTargets = targetIntervals match {
       case None => // Split using the FASTA
-        new GenerateRegionsFromFasta(ref=ref, regionSize=Some(regionSize.toInt)) with PipeWithNoResources[Nothing,Text]
+        new GenerateRegionsFromFasta(ref=ref, regionSize=Some(regionSize.toInt)) with PipeOut[Text]
       case Some(targets) => // Split using the intervals
         val cat  = new ShellCommand("cat", targets.toAbsolutePath.toString) with PipeWithNoResources[Nothing,Text]
         val grep = new ShellCommand("grep", "-v", "^@") with Pipe[Text,Text]

--- a/tasks/src/main/scala/dagr/tasks/vc/FreeBayes.scala
+++ b/tasks/src/main/scala/dagr/tasks/vc/FreeBayes.scala
@@ -24,15 +24,13 @@
 
 package dagr.tasks.vc
 
-import dagr.commons.io.Io
 import dagr.core.config.Configuration
 import dagr.core.execsystem.{Cores, Memory, ResourceSet}
 import dagr.core.tasksystem._
+import dagr.tasks.DagrDef.{PathToBam, PathToFasta, PathToIntervals, PathToVcf}
 import dagr.tasks.DataTypes._
-import dagr.tasks.DagrDef
 import dagr.tasks.jeanluc.GenerateRegionsFromFasta
 import dagr.tasks.vc.FreeBayes._
-import DagrDef.{PathToBam, PathToFasta, PathToIntervals, PathToVcf}
 
 import scala.collection.mutable.ListBuffer
 
@@ -181,7 +179,9 @@ abstract class FreeBayes(val ref: PathToFasta,
     val vcfuniq        = new ShellCommand(configureExecutableFromBinDirectory(VcfLibBinConfigKey, "vcfuniq").toString)                     with PipeWithNoResources[Vcf,Vcf]
     val bgzip          = if (compress) new ShellCommand(configureExecutableFromBinDirectory(BgzipBinConfigKey, "bgzip").toString, "-c")    with PipeWithNoResources[Vcf,Vcf] else Pipes.empty[Vcf]
 
-    List((generateTargets | freebayesParallel | vcffirstheader | vcfstreamsort | vcfuniq | bgzip > vcf) withName (this.name + "PipeChain"))
+    val pipeChain = generateTargets | freebayesParallel | vcffirstheader | vcfstreamsort | vcfuniq | bgzip > vcf
+
+    List(pipeChain withName (this.name + "PipeChain"))
   }
 }
 

--- a/tasks/src/main/scala/dagr/tasks/vc/FreeBayes.scala
+++ b/tasks/src/main/scala/dagr/tasks/vc/FreeBayes.scala
@@ -24,6 +24,7 @@
 
 package dagr.tasks.vc
 
+import dagr.commons.io.Io
 import dagr.core.config.Configuration
 import dagr.core.execsystem.{Cores, Memory, ResourceSet}
 import dagr.core.tasksystem._
@@ -54,8 +55,6 @@ object FreeBayes {
 
   /** Somatic Defaults */
   val DefaultMinAlternateAlleleFraction = Some(0.1.toFloat)
-
-  protected val PipeArg = "\\\n  |"
 }
 
 /**
@@ -150,7 +149,7 @@ abstract class FreeBayes(val ref: PathToFasta,
     val vcffirstheader = new ShellCommand(configureExecutableFromBinDirectory(VcfLibScriptsConfigKey, "vcffirstheader").toString)          with Pipe[Vcf,Vcf]
     val vcfstreamsort  = new ShellCommand(configureExecutableFromBinDirectory(VcfLibBinConfigKey, "vcfstreamsort").toString, "-w", "1000") with Pipe[Vcf,Vcf]
     val vcfuniq        = new ShellCommand(configureExecutableFromBinDirectory(VcfLibBinConfigKey, "vcfuniq").toString)                     with Pipe[Vcf,Vcf]
-    val bgzip           = if (compress) new ShellCommand(configureExecutableFromBinDirectory(BgzipBinConfigKey, "bgzip").toString, "-c")   with Pipe[Vcf,Vcf] else Pipes.empty[Vcf]
+    val bgzip          = if (compress) new ShellCommand(configureExecutableFromBinDirectory(BgzipBinConfigKey, "bgzip").toString, "-c")    with Pipe[Vcf,Vcf] else Pipes.empty[Vcf]
 
     List((generateTargets | freebayesParallel | vcffirstheader | vcfstreamsort | vcfuniq | bgzip > vcf) withName this.name)
   }

--- a/tasks/src/main/scala/dagr/tasks/vc/FreeBayes.scala
+++ b/tasks/src/main/scala/dagr/tasks/vc/FreeBayes.scala
@@ -26,6 +26,7 @@ package dagr.tasks.vc
 
 import dagr.core.config.Configuration
 import dagr.core.execsystem.{Cores, Memory, ResourceSet}
+import dagr.core.tasksystem.Pipes.PipeWithNoResources
 import dagr.core.tasksystem._
 import dagr.tasks.DagrDef.{PathToBam, PathToFasta, PathToIntervals, PathToVcf}
 import dagr.tasks.DataTypes._

--- a/tasks/src/main/scala/dagr/tasks/vc/FreeBayes.scala
+++ b/tasks/src/main/scala/dagr/tasks/vc/FreeBayes.scala
@@ -57,6 +57,56 @@ object FreeBayes {
   val DefaultMinAlternateAlleleFraction = Some(0.1.toFloat)
 }
 
+/** Task to run freepayes using GNP parallel. This assumes regions are being piped into this task via a pipe chain. */
+class FreeBayesParallel(val ref: PathToFasta,
+                        val bam: List[PathToBam],
+                        val somatic: Boolean,
+                        val memory: Memory,
+                        val minThreads: Int,
+                        val maxThreads: Int,
+                        val useBestNAlleles: Option[Int],
+                        val maxCoverage: Option[Int],
+                        val minRepeatEntropy: Option[Int],
+                        val minAlternateAlleleFraction: Option[Float] = None)
+  extends ProcessTask with Configuration with VariableResources with Pipe[Text,Vcf] {
+
+  override def args: Seq[Any] = {
+    val buffer = ListBuffer[Any]()
+
+    /** Trivial method to make the adding of arguments to the list of arguments more readable below. */
+    def applyArgs[T](arg: String, value: Option[T]): Unit = value.foreach(buffer.append(arg, _))
+    // Runs FreeBayes on multiple regions in parallel.
+    buffer.append("parallel", "-k", "-j", s"$numThreads")
+    // FreeBayes args
+    buffer.append(configureExecutable(FreeBayesExecutableConfigKey, "freebayes"))
+    buffer.append("-f", ref)
+    applyArgs("--use-best-n-alleles",     useBestNAlleles)
+    applyArgs("--max-coverage",           maxCoverage)
+    applyArgs("--min-repeat-entropy",     minRepeatEntropy)
+    applyArgs("--min-alternate-fraction", minAlternateAlleleFraction)
+    if (somatic) {
+      buffer.append("--pooled-discrete", "--pooled-continuous", "--genotype-qualities")
+      buffer.append("--report-genotype-likelihood-max", "--allele-balance-priors-off")
+    }
+    bam.foreach(b => buffer.append("-b", b.toAbsolutePath))
+    buffer.append("--region", "{}")
+
+    buffer.toSeq
+  }
+
+
+  /** Attempts to pick the resources required to run. The required resources are:
+    * 1) Cores  = the cores for freebayes plus one additional core to account for the other scripts
+    * 2) Memory = a fixed amount.
+    */
+  override def pickResources(availableResources: ResourceSet): Option[ResourceSet] = {
+    availableResources.subset(minCores = Cores(minThreads+1), maxCores = Cores(maxThreads+1), memory = memory)
+  }
+
+  // NB: we could re-implement the FreeBayes Parallel script as individual tasks, but keep this for now.
+  protected def numThreads = (this.resources.cores.value - 1).toInt
+}
+
 /**
   * Task for running FreeBayes, based on:
   *   https://github.com/chapmanb/bcbio-nextgen/blob/master/bcbio/variation/freebayes.py
@@ -93,21 +143,10 @@ abstract class FreeBayes(val ref: PathToFasta,
                          val useBestNAlleles: Option[Int],
                          val maxCoverage: Option[Int],
                          val minRepeatEntropy: Option[Int],
-                         minAlternateAlleleFraction: Option[Float] = None) extends Task with Configuration with VariableResources {
-
-  // NB: we could re-implement the FreeBayes Parallel script as individual tasks, but keep this for now.
-  protected def numThreads = (this.resources.cores.value - 1).toInt
+                         minAlternateAlleleFraction: Option[Float] = None) extends Task with Configuration {
 
   if (!somatic) {
     minAlternateAlleleFraction.foreach { af => throw new IllegalArgumentException("Germline calling but minAlternateAlleleFraction is defined") }
-  }
-
-  /** Attempts to pick the resources required to run. The required resources are:
-    * 1) Cores  = the cores for freebayes plus one additional core to account for the other scripts
-    * 2) Memory = a fixed amount.
-    */
-  override def pickResources(availableResources: ResourceSet): Option[ResourceSet] = {
-    availableResources.subset(minCores = Cores(minThreads + 1), maxCores = Cores(maxThreads + 1), memory = memory)
   }
 
   /** Sets the arguments for FreeBayes.  For somatic calling, there should be two bams, a tumor bam then normal bam. */
@@ -123,27 +162,18 @@ abstract class FreeBayes(val ref: PathToFasta,
         cat | grep | awk
     }
 
-    // the args to the freebayes parallel command
-    val buffer = ListBuffer[Any]()
-    /** Trivial method to make the adding of argume
-      * nts to the list of arguments more readable below. */
-    def applyArgs[T](arg: String, value: Option[T]): Unit = value.foreach(buffer.append(arg, _))
-    // Runs FreeBayes on multiple regions in parallel.
-    buffer.append("parallel", "-k", "-j", s"$numThreads")
-    // FreeBayes args
-    buffer.append(configureExecutable(FreeBayesExecutableConfigKey, "freebayes"))
-    buffer.append("-f", ref)
-    applyArgs("--use-best-n-alleles",     useBestNAlleles)
-    applyArgs("--max-coverage",           maxCoverage)
-    applyArgs("--min-repeat-entropy",     minRepeatEntropy)
-    applyArgs("--min-alternate-fraction", minAlternateAlleleFraction)
-    if (somatic) {
-      buffer.append("--pooled-discrete", "--pooled-continuous", "--genotype-qualities")
-      buffer.append("--report-genotype-likelihood-max", "--allele-balance-priors-off")
-    }
-    bam.foreach(b => buffer.append("-b", b.toAbsolutePath))
-    buffer.append("--region", "{}")
-    val freebayesParallel = new ShellCommand(buffer.map(_.toString):_*) with Pipe[Text,Vcf]
+    val freebayesParallel = new FreeBayesParallel(
+      ref=ref,
+      bam=bam,
+      somatic=somatic,
+      memory=memory,
+      minThreads=minThreads,
+      maxThreads=maxThreads,
+      useBestNAlleles=useBestNAlleles,
+      maxCoverage=maxCoverage,
+      minRepeatEntropy=minRepeatEntropy,
+      minAlternateAlleleFraction=minAlternateAlleleFraction
+    )
 
     // Make a header, sort it, uniq it (for edge regions), and output it
     val vcffirstheader = new ShellCommand(configureExecutableFromBinDirectory(VcfLibScriptsConfigKey, "vcffirstheader").toString)          with PipeWithNoResources[Vcf,Vcf]


### PR DESCRIPTION
Using Pipes in FilterFreeBayesCalls. This also requires a ShellCommand class that does not modify any arguments with
quotes or the like.  Also updated FreeBayes filtering based on BCBIO best practices.
