### PR TITLE
Switch to new linker ordering.

### DIFF
--- a/pipelines/src/main/scala/dagr/pipelines/DnaResequencingFromUnmappedBamPipeline.scala
+++ b/pipelines/src/main/scala/dagr/pipelines/DnaResequencingFromUnmappedBamPipeline.scala
@@ -104,7 +104,7 @@ class DnaResequencingFromUnmappedBamPipeline
     )
     val calculateP = new CalculateDownsamplingProportion(PathUtil.pathTo(prefix + ".quality_yield_metrics.txt"), downsampleToReads)
     val downsample = new DownsampleSam(in=mappedBam, out=dsMappedBam, proportion=1, accuracy=Some(0.00001))
-    val linker     = Linker(calculateP, downsample){(ds, cp) => ds.proportion = cp.proportion}
+    val linker     = Linker(calculateP, downsample){(cp, ds) => ds.proportion = cp.proportion}
     bwa ==> yieldMetrics ==> calculateP ==> linker ==> downsample
 
     ///////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This just happened to compile previously since the member variables for the
two classes were the same.

I think this has been broken since b5de82ef801ae7f7459039d5294867ed34ad68c8 or perhaps it was never correct.
