### PR TITLE
Per-target metrics should end with ".txt".

### DIFF
--- a/tasks/src/main/scala/dagr/tasks/picard/CollectTargetedPcrMetrics.scala
+++ b/tasks/src/main/scala/dagr/tasks/picard/CollectTargetedPcrMetrics.scala
@@ -33,7 +33,7 @@ import scala.collection.mutable.ListBuffer
 
 object CollectTargetedPcrMetrics {
   def perTargetMetricsPath(metricsFile: Path): Path = {
-    PathUtil.pathTo(metricsFile.toString + ".per_target")
+    PathUtil.replaceExtension(metricsFile, ".per_target" + PicardOutput.Text)
   }
 
   def metricsExtension: String = ".targeted_pcr_metrics"


### PR DESCRIPTION
@tfenne fairly controversial change (`</sarcasm>`) so I will merge if I don't hear back in a few days.
