### PR TITLE
Various fixes for usages derived from the @arg annotation.

### DIFF
--- a/sopt/src/main/java/dagr/sopt/cmdline/ArgAnnotation.java
+++ b/sopt/src/main/java/dagr/sopt/cmdline/ArgAnnotation.java
@@ -45,15 +45,20 @@ public @interface ArgAnnotation {
      * prefixed on the command-line with a double dash (--).  If not specified
      * then default is used, which is to translate the field name into a GNU style
      * option name by breaking words on camel case, joining words back together with
-     * hyphens, and converting to lower case (e.g. myThing => my-thing).
+     * hyphens, and converting to lower case (e.g. myThing => my-thing).  The
+     * resulting value should be different than {@link #flag()}.
      * @return Selected full name, or "" to use the default.
      */
     String name() default "";
 
     /**
-     * Specified short name of the command.  Short names should be prefixed
-     * with a single dash.  ArgAnnotation values can directly abut single-char
-     * short names or be separated from them by a space.
+     * Specified short name of the command.  Single value short names should be
+     * prefixed on the command-line with a single dash.  Multi-character short-names
+     * will be treated like {@link #name()}. ArgAnnotation values can directly abut
+     * single-char short names or be separated from them by a space.  The short name
+     * should always have length less than or equal to {@link #name()} if the latter
+     * is not empty and is not derived from the field name.  Regardless, they should
+     * not have the same value.
      * @return Selected short name, or "" for none.
      */
     String flag() default "";

--- a/sopt/src/main/scala/dagr/sopt/cmdline/ClpReflectiveBuilder.scala
+++ b/sopt/src/main/scala/dagr/sopt/cmdline/ClpReflectiveBuilder.scala
@@ -147,8 +147,22 @@ private[sopt] class ClpArgument(declaringClass: Class[_],
 
   lazy val isSpecial: Boolean   = annotation.exists(_.special())
   lazy val isSensitive: Boolean = annotation.exists(_.sensitive())
-  lazy val longName: String     = if (annotation.isDefined && annotation.get.name.nonEmpty) annotation.get.name else StringUtil.camelToGnu(name)
-  lazy val shortName: String    = annotation.map(_.flag()).getOrElse("")
+  /** longName should never be empty.  See [ArgAnnotation] for rules around 'flag', 'name', and the field name */
+  lazy val (shortName, longName) = {
+    val flagName = annotation.map(_.flag()).getOrElse("")
+    if (annotation.isDefined && annotation.get.name.nonEmpty) {
+      if (flagName.length > annotation.get.name.length) {
+        throw new IllegalStateException("The @arg flag (short name) should be shorter than the @arg name (long name)")
+      }
+      (flagName, annotation.get.name)
+    } else {
+      // It is ok that the length of the long name when derived from the field name is shorter than shortName since
+      // we will just swap the two.
+      val derivedName = StringUtil.camelToGnu(name)
+      if (derivedName == flagName) ("", flagName)
+      else if (flagName.length < derivedName.length) (flagName, derivedName) else (derivedName, flagName)
+    }
+  }
   lazy val doc: String          = annotation.map(_.doc()).getOrElse("")
   lazy val isCommon: Boolean    = annotation.exists(_.common())
   lazy val minElements: Int     = if (isCollection) {

--- a/sopt/src/main/scala/dagr/sopt/cmdline/ClpReflectiveBuilder.scala
+++ b/sopt/src/main/scala/dagr/sopt/cmdline/ClpReflectiveBuilder.scala
@@ -121,15 +121,15 @@ private[sopt] class ClpArgumentLookup(args: ClpArgument*) extends ArgumentLookup
   * must have default values as there is no other way for them to get values.
   */
 private[sopt] class ClpArgument(declaringClass: Class[_],
-                                   index: Int,
-                                   name: String,
-                                   defaultValue: Option[Any],
-                                   argumentType: Class[_],
-                                   unitType: Class[_],
-                                   constructableType: Class[_],
-                                   typeName : String,
-                                   val annotation: Option[arg]
-                                  ) extends Argument(declaringClass, index, name, defaultValue, argumentType, unitType, constructableType, typeName) {
+                                index: Int,
+                                name: String,
+                                defaultValue: Option[Any],
+                                argumentType: Class[_],
+                                unitType: Class[_],
+                                constructableType: Class[_],
+                                typeName : String,
+                                val annotation: Option[arg]
+                               ) extends Argument(declaringClass, index, name, defaultValue, argumentType, unitType, constructableType, typeName) {
 
   def hidden: Boolean = annotation.isEmpty
 


### PR DESCRIPTION
The fixes are described in the second commit message pasted here:

Various fixes for usages derived from the `@arg` annotation.

Enforce if both 'flag' and 'name' are given in the `@arg` annotation, the
length of 'flag' is less than or equal to the length of 'name'.  It is ok 
if the length of 'name' derived from the constructor-parameter/field is 
less than the length of 'flag', and in this cause we'll print 'flag' 
second. Examples:
1. `@arg(flag="abc", name="a") val a: T` should be illegal
2. `@arg(flag="abc") val a: T` will have usage "-a T, --abc=T"
Previously it would not check and print the following usages for 1-2 
above:
1. "-abc T, --a=T". Note that specifying either "-abc T" or "--a T"
wouldn't work.
2. "-abc T, -a=T". Note that specifying "-abc T" wouldn't work.

Format a single-character flag correctly if specified in name or the 
variable/field is a single-character.
- `@arg(name="a") val abc: T` will have usage "-a T". 
- `@arg val a: T` will have usage "-a T". 

Add a regression test for the 'name' field being camel case:
- `@arg(name="aB") val a: T` will have usage "--aB=T".

Fix the usage for multi-character flag arguments.  For example, if
`@arg(flag="abc") val abcd: T` then the usage will be 
"--abc=T, --abcd=T"; it was previously "-abc T, --abcd=T".

Make it ok for the 'flag' and derived 'name' are the same, but only 
print out one: `@arg(flag="a") val a: T` will be "-a T".

Updated the documentation for ArgAnnotation for all the above.
