### PR TITLE
Add an optional sub-directory to Configuration.configureExecutableFro…

### DIFF
--- a/core/src/main/scala/dagr/core/config/Configuration.scala
+++ b/core/src/main/scala/dagr/core/config/Configuration.scala
@@ -198,14 +198,18 @@ private[config] trait ConfigurationLike extends LazyLogging {
     *
     * @param binPath the configuration path to look up, representing the directory containing the executable
     * @param executable the default name of the executable
+    * @param subDir optionally a sub-directory within the bin-directory containing the executable.
     * @return An absolute path to the executable to use
     */
-  def configureExecutableFromBinDirectory(binPath: String, executable: String) : Path = {
+  def configureExecutableFromBinDirectory(binPath: String, executable: String, subDir: Option[Path] = None) : Path = {
     Configuration.RequestedKeys += binPath
 
     optionallyConfigure[Path](binPath) match {
       case Some(exec) =>
-        pathTo(exec.toString, executable)
+        subDir match {
+          case Some(dir) => pathTo(exec.toString, dir.toString, executable)
+          case None      => pathTo(exec.toString, executable)
+        }
       case None => findInPath(executable) match {
         case Some(exec) => exec
         case None => throw new Generic(s"Could not configurable executable. Config path '$binPath' is not defined and executable '$executable' is not in PATH.")

--- a/core/src/test/scala/dagr/core/config/ConfigurationTest.scala
+++ b/core/src/test/scala/dagr/core/config/ConfigurationTest.scala
@@ -24,7 +24,7 @@
 package dagr.core.config
 
 import java.io.PrintWriter
-import java.nio.file.{Files, Path}
+import java.nio.file.{Files, Path, Paths}
 import java.time.Duration
 
 import com.typesafe.config.{ConfigException, ConfigFactory}
@@ -131,6 +131,7 @@ class ConfigurationTest extends UnitSpec {
   it should "find executables" in {
     conf.configureExecutable("some-executable", "n/a") shouldBe PathUtil.pathTo("/does/not/exist")
     conf.configureExecutableFromBinDirectory("some-executable", "exec") shouldBe PathUtil.pathTo("/does/not/exist/exec")
+    conf.configureExecutableFromBinDirectory("some-executable", "exec", Some(Paths.get("some", "subdir"))) shouldBe PathUtil.pathTo("/does/not/exist/some/subdir/exec")
 
     var java = conf.configureExecutable("java.exe", "java")
     java.getFileName.toString shouldBe "java"


### PR DESCRIPTION
…mBinDirectory.

In many cases we have a root install directory for a tool, and sub-directories that contain scripts or other executables.  This change allows us to have a single configuration key for the root directory, and specify a sub-directory in addition to the executable name.
