### PR TITLE
If we attempt to terminate a task that has succeeded, mark it as succ…

### DIFF
--- a/core/src/main/scala/dagr/core/execsystem/TaskStatus.scala
+++ b/core/src/main/scala/dagr/core/execsystem/TaskStatus.scala
@@ -46,7 +46,7 @@ object TaskStatus extends Enumeration {
     * @return true if the task is done, false otherwise
     */
   def isTaskDone(taskStatus: TaskStatus, failedIsDone: Boolean = true): Boolean = {
-    (isTaskFailed(taskStatus) && failedIsDone) || SUCCEEDED == taskStatus || MANUALLY_SUCCEEDED == taskStatus
+    (isTaskFailed(taskStatus) && failedIsDone) || SUCCEEDED == taskStatus || MANUALLY_SUCCEEDED == taskStatus || STOPPED == taskStatus
   }
 
   /** Checks if a task with a given status is not done.


### PR DESCRIPTION
…eeded not stopped.

Consider the case we have a failed tasks, so the `TaskManager` terminates all running tasks, but some of those running tasks have actually completed successfully.  Previously they would have status `STOPPED` while they should be `SUCCEEDED`.  Furthermore, running tasks that were terminated (interrupted) had status `FAILED_COMMAND` rather than `STOPPED`.  This kills two birds with one stone.
