### PR TITLE
Do not merge: Expose a few command line options for scheduling strategies.

### DIFF
--- a/core/src/main/java/dagr/core/execsystem/SchedulingStrategy.java
+++ b/core/src/main/java/dagr/core/execsystem/SchedulingStrategy.java
@@ -1,0 +1,36 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package dagr.core.execsystem;
+
+/**
+ * For exposing the various scheduling strategies on the command line.
+ */
+public enum SchedulingStrategy {
+    AnyTask,
+    MinTaskId,
+    MaxCores,
+    MaxMemory
+}

--- a/core/src/main/scala/dagr/core/cmdline/DagrCoreMain.scala
+++ b/core/src/main/scala/dagr/core/cmdline/DagrCoreMain.scala
@@ -143,7 +143,9 @@ class DagrCoreMain(
   @arg(doc = "Write an execution report to this file, otherwise write to the stdout", common = true)
   val report: Option[Path] = None,
   @arg(doc = "Provide an top-like interface for tasks with the give delay in seconds. This suppress info logging.")
-  var interactive: Boolean = false
+  var interactive: Boolean = false,
+  @arg(doc = "The scheduling strategy when choosing between tasks whose resource needs can be met.")
+  var schedulingStrategy: SchedulingStrategy = SchedulingStrategy.AnyTask
 ) extends LazyLogging {
 
   // These are not optional, but are only populated during configure()
@@ -189,7 +191,7 @@ class DagrCoreMain(
       this.reportPath.foreach(p => Io.assertCanWriteFile(p, parentMustExist=false))
 
       val resources = SystemResources(cores = cores.map(Cores(_)), totalMemory = memory.map(Memory(_)))
-      this.taskManager = Some(new TaskManager(taskManagerResources=resources, scriptsDirectory = scriptsDirectory, logDirectory = logDirectory))
+      this.taskManager = Some(new TaskManager(taskManagerResources=resources, scriptsDirectory = scriptsDirectory, logDirectory = logDirectory, scheduler = NaiveScheduler(schedulingStrategy)))
     }
     catch {
       case v: ValidationException => throw v

--- a/core/src/main/scala/dagr/core/execsystem/TaskManager.scala
+++ b/core/src/main/scala/dagr/core/execsystem/TaskManager.scala
@@ -77,7 +77,7 @@ object TaskManagerDefaults extends LazyLogging {
   }
 
   /** @return the default scheduler */
-  def defaultScheduler: Scheduler = new NaiveScheduler
+  def defaultScheduler: Scheduler = NaiveScheduler()
 }
 
 /** Defaults and utility methods for a TaskManager. */

--- a/core/src/test/scala/dagr/core/execsystem/NaiveSchedulerTest.scala
+++ b/core/src/test/scala/dagr/core/execsystem/NaiveSchedulerTest.scala
@@ -30,7 +30,7 @@ import dagr.commons.util.UnitSpec
 import scala.collection.mutable.ListBuffer
 
 class NaiveSchedulerTest extends UnitSpec with LazyLogging {
-  private val scheduler = new NaiveScheduler()
+  private val scheduler = NaiveScheduler()
 
   private val systemCores: Cores = Cores(2)
   private val systemMemory: Memory = Memory("2G")
@@ -170,7 +170,7 @@ class NaiveSchedulerTest extends UnitSpec with LazyLogging {
   }
 
   it should "not schedule tasks concurrently with more Cores than are defined in the system." in {
-    val scheduler = new NaiveScheduler()
+    val scheduler = NaiveScheduler()
     val systemCores: Cores = Cores(4)
     val systemMemory: Memory = Memory("4G")
     val jvmMemory: Memory = Memory.none


### PR DESCRIPTION
@tfenne looking for some feedback.  My only regret is having to use a Java enum to expose the strategy options on the command line.  Perhaps I could play with `ClassFinder` to find all classes that extend `SelectTaskScheduler` instead.  Tests will be added and code cleaned up when the idea becomes more fully formed.
