### PR TITLE
Improve log messages about task status.

### DIFF
--- a/core/src/main/scala/dagr/core/execsystem/TaskStatus.scala
+++ b/core/src/main/scala/dagr/core/execsystem/TaskStatus.scala
@@ -28,16 +28,15 @@ import dagr.core.tasksystem.Task
 /** The state for a [[Task]]. */
 object TaskStatus extends Enumeration {
   type TaskStatus = Value
-  val UNKNOWN, /** The task state is unknown, most likely not considered */
-  STARTED, /** The task has been started */
-  STOPPED, /* The task has been stopped */
-  FAILED_GET_TASKS, /* The task could not get the list of tasks */
-  FAILED_SCHEDULING, /* The task could not execute after scheduling */
-  FAILED_COMMAND, /* The task command has failed */
-  FAILED_ON_COMPLETE, /* The task has failed when trying to run its onComplete method */
-  SUCCEEDED, /* The task has succeeded */
-  MANUALLY_SUCCEEDED /* The task was manually succeeded */
-  = Value
+  val UNKNOWN            = Value("is unknown") /** The task state is unknown, most likely not considered */
+  val STARTED            = Value("has been started") /** The task has been started */
+  val STOPPED            = Value("has been stopped") /** The task has been stopped */
+  val FAILED_GET_TASKS   = Value("has failed (could not get the list of tasks)") /** The task could not get the list of tasks */
+  val FAILED_SCHEDULING  = Value("has failed (could not start executing after scheduling)") /** The task could not execute after scheduling */
+  val FAILED_COMMAND     = Value("has failed (execution)") /** The task command has failed */
+  val FAILED_ON_COMPLETE = Value("has failed (running the onComplete method)") /** The task has failed when trying to run its onComplete method */
+  val SUCCEEDED          = Value("has succeeded") /** The task has succeeded */
+  val MANUALLY_SUCCEEDED = Value("has succeeded (manually)") /**The task was manually succeeded */
 
   /** Checks if a task with a given status is done.
     *


### PR DESCRIPTION
@tfenne this was really bugging me.  I am open to the exact format that we display, but I do want to know the task name, status, attempt index, and scheduled memory at a minimum.