### PR TITLE
Estimate the resources needed for a VariableResources task.

### DIFF
--- a/core/src/main/scala/dagr/core/execsystem/TaskManager.scala
+++ b/core/src/main/scala/dagr/core/execsystem/TaskManager.scala
@@ -555,11 +555,15 @@ class TaskManager(taskManagerResources: SystemResources = TaskManagerDefaults.de
       if (!allDone && runningTasks.isEmpty && tasksToSchedule.isEmpty) {
         logger.error(s"There are ${readyTasks.size} tasks ready to be scheduled but not enough system resources available.")
         readyTasks.foreach { readyTask =>
-          val (resourcesType: String, resources: Option[ResourceSet]) = readyTask match {
-            case t: FixedResources    => ("FixedResources", Some(t.resources))
-            case t: VariableResources => ("VariableResources", Some(t.resources))
-            case t: Schedulable       => ("Schedulable", t.pickResources(new ResourceSet(Cores(Integer.MAX_VALUE), Memory.infinite)))
-            case t                    => ("Unknown Type", None)
+          val resourcesType: String = readyTask match {
+            case _: FixedResources    => "FixedResources"
+            case _: VariableResources => "VariableResources"
+            case _: Schedulable       => "Schedulable"
+            case _                    => "Unknown Type"
+          }
+          val resources: Option[ResourceSet] = readyTask match {
+            case t: Schedulable => t.minResources(new ResourceSet(taskManagerResources.cores, taskManagerResources.systemMemory))
+            case _              => None
           }
           val cores  = resources.map(_.cores.toString).getOrElse("?")
           val memory = resources.map(_.memory.prettyString).getOrElse("?")

--- a/core/src/main/scala/dagr/core/tasksystem/Schedulable.scala
+++ b/core/src/main/scala/dagr/core/tasksystem/Schedulable.scala
@@ -23,13 +23,55 @@
  */
 package dagr.core.tasksystem
 
-import dagr.core.execsystem.{Cores, Memory, ResourceSet}
+import dagr.core.execsystem.{Cores, Memory, Resource, ResourceSet}
+
+object Schedulable {
+
+  /** The multiple of the system resources to use when searching for the resources with which a task can execute. */
+  private val ResourceMultiple: Int = 16
+
+  /** The maximum # cores to use when searching for the resources with which a task can execute. */
+  private[tasksystem] val EndCores: Cores = {
+    val cores    = Resource.systemCores.value * ResourceMultiple
+    val minCores = 64
+    if (cores < minCores) Cores(minCores) else Cores(cores)
+  }
+
+  /** The maximum amount of memory to use when searching for the resources with which a task can execute. */
+  private[tasksystem] val EndMemory: Memory = {
+    val memory    = Resource.systemMemory.value * ResourceMultiple
+    val minMemory = Memory("256g")
+    if (memory < minMemory.value) minMemory else Memory(memory)
+  }
+
+  /** The maximum resources to use when searching for the resources with which a task can execute. */
+  private[tasksystem] val EndResources: ResourceSet = new ResourceSet(cores=EndCores, memory=EndMemory)
+
+  /** The amount of memory per core when searching for the memory with which a task can execute. */
+  private[tasksystem] val MemoryPerCore = Memory("1g")
+
+  /** The minimum amount of memory to start when searching for the memory with which a task can execute. */
+  private[tasksystem] val StartMemory = Memory("256m")
+
+  /** The minimum amount of memory to increase the memory when searching for the memory with which a task can execute. */
+  private[tasksystem] val StepMemory: Memory = {
+    val stepMemory = Memory(EndMemory.value / 100)
+    if (stepMemory < StartMemory) stepMemory
+    else StartMemory
+  }
+
+  /** A single core! */
+  private[tasksystem] val OneCore: Cores = Cores(1)
+}
 
 /**
   * Traits that isolates methods about how Tasks interact with the Scheduler, and allows
   * for multiple implementations independent from the Task hierarchy.
   */
 trait Schedulable {
+  
+  import Schedulable.{EndCores, EndMemory, MemoryPerCore, OneCore, StartMemory, StepMemory}
+  
   /**
     * Given a non-null ResourceSet representing the available resources at this moment in time
     * return either a ResourceSet that is a subset of the available resources in which the task
@@ -48,6 +90,65 @@ trait Schedulable {
     * @param resources the set of resources that the task will be run with
     */
   def applyResources(resources : ResourceSet): Unit
+
+  /** A crude attempt at estimating the minimum cores needed by assuming a fixed maximum memory. */
+  private[tasksystem] def minCores(start: Cores = OneCore, end: Cores = EndCores, step: Cores = OneCore, maxMemory: Memory = EndMemory): Option[Cores] = {
+    // first check that the search will succeed, then test a range of values for cores
+    this.pickResources(availableResources = new ResourceSet(end, maxMemory)).flatMap { _ =>
+      (start.value to end.value by step.value).flatMap { cores =>
+        val availableResources = new ResourceSet(Cores(cores), maxMemory)
+        this.pickResources(availableResources = availableResources).map(_.cores)
+      }.headOption
+    }
+  }
+
+  /** A crude attempt at estimating the minimum memory needed by assuming a fixed maximum number of cores. */
+  private[tasksystem] def minMemory(start: Memory = StartMemory, end: Memory = EndMemory, step: Memory = StepMemory, maxCores: Cores = EndCores): Option[Memory] = {
+    // first check that the search will succeed, then test a range of values for memory
+    this.pickResources(availableResources = new ResourceSet(maxCores, end)).flatMap { _ =>
+      (start.value to end.value by step.value).flatMap { memory =>
+        val availableResources = new ResourceSet(maxCores, Memory(memory))
+        this.pickResources(availableResources = availableResources).map(_.memory)
+      }.headOption
+    }
+  }
+
+  /** A crude attempt at estimating the minimum resources by assuming a fixed ratio of memory per core. */
+  private[tasksystem] def minCoresAndMemory(start: Cores = OneCore, end: Cores = EndCores, step: Cores = OneCore, memoryPerCore: Memory = MemoryPerCore): Option[ResourceSet] = {
+    (start.value to end.value by step.value).flatMap { cores =>
+      val availableResources = new ResourceSet(Cores(cores), Memory((memoryPerCore.value * cores).toLong))
+      this.pickResources(availableResources = availableResources)
+    }.headOption
+  }
+
+  /**
+    * Given a non-null ResourceSet representing the maximum available resources return either a
+    * ResourceSet that is a subset of the available resources in which the task can run, or None
+    * if the task cannot run in the maximum resources.
+    *
+    * First estimates the # of cores by assuming an infinite amount of memory, and then estimates
+    * the amount of memory assuming an infinite # of cores.  If either does not yield a value or if
+    * the task cannot run with the combination of the two, then try a various combinations of cores
+    * and memory where we assume a fixed ratio between cores and memory (ex. 1g per core).
+    *
+    * @param maximumResources The maximum system resources available to the task.
+    * @return Either a ResourceSet of the subset of resources that this task can run with, or None
+    */
+  private[core] def minResources(maximumResources: ResourceSet = new ResourceSet(cores=EndCores, memory=EndMemory)): Option[ResourceSet] = {
+    val cores  = minCores(end=maximumResources.cores, maxMemory=maximumResources.memory)
+    val memory = minMemory(end=maximumResources.memory, maxCores=maximumResources.cores)
+    (cores, memory) match {
+      case (Some(c), Some(m)) => this.pickResources(maximumResources.copy(cores=c, memory=m))
+      case _                  =>
+        // try a combination of cores and memory with a fixed ratio between the two.
+        val startMemoryPerCore = StartMemory.value
+        val endMemoryPerCore   = maximumResources.memory.value
+        val stepMemoryPerCore  = StepMemory.value
+        (startMemoryPerCore to endMemoryPerCore by stepMemoryPerCore).flatMap { memoryPerCore =>
+          this.minCoresAndMemory(end=maximumResources.cores, memoryPerCore=Memory(memoryPerCore)).flatMap(this.pickResources)
+        }.headOption
+    }
+  }
 }
 
 /**
@@ -66,7 +167,9 @@ private[tasksystem] trait ScheduleWithEmptyDefaultResources extends Schedulable 
   * set of values.
   */
 trait FixedResources extends ScheduleWithEmptyDefaultResources {
-  requires(ResourceSet(Cores(1), Memory("32M")))
+  import Schedulable.{EndResources, OneCore}
+
+  requires(ResourceSet(OneCore, Memory("32M")))
 
   /** Sets the resources that are required by this task, overriding all previous values. */
   def requires(resources: ResourceSet) : this.type = {
@@ -81,9 +184,24 @@ trait FixedResources extends ScheduleWithEmptyDefaultResources {
   def requires(cores: Double, memory: String) : this.type = { requires(Cores(cores), Memory(memory)) }
 
   /**
-    * Implemented to take the the fixed amount of cores and memory from the provided resource set.
+    * Implemented to take the fixed amount of cores and memory from the provided resource set.
     */
   override def pickResources(availableResources: ResourceSet): Option[ResourceSet] = availableResources.subset(this.resources)
+
+  /**
+    * Given a non-null ResourceSet representing the maximum available resources return either a
+    * ResourceSet that is a subset of the available resources in which the task can run, or None
+    * if the task cannot run in the maximum resources.
+    *
+    * Since a the task has a fixed amount of resources, returns None if there is not enough resources,
+    * or the fixed amount of cores and memory from the provided resource set.
+    *
+    * @param maximumResources The maximum system resources available to the task.
+    * @return Either a ResourceSet of the subset of resources that this task can run with, or None
+    */
+  override private[core] def minResources(maximumResources: ResourceSet = EndResources): Option[ResourceSet] = {
+    this.pickResources(maximumResources)
+  }
 }
 
 trait VariableResources extends ScheduleWithEmptyDefaultResources {

--- a/core/src/test/scala/dagr/core/tasksystem/SchedulableTest.scala
+++ b/core/src/test/scala/dagr/core/tasksystem/SchedulableTest.scala
@@ -1,0 +1,122 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package dagr.core.tasksystem
+
+import dagr.commons.util.UnitSpec
+import dagr.core.execsystem.{Cores, Memory, ResourceSet}
+import org.scalatest.OptionValues
+
+class SchedulableTest extends UnitSpec with OptionValues {
+
+  private val fixedTask = new FixedResources {
+    override def applyResources(resources: ResourceSet) = Unit
+  }
+
+  // A variable task that takes twice as much memory in GB as available cores.
+  private val doubleMemoryTask = new VariableResources {
+    override def pickResources(availableResources: ResourceSet) = {
+      val cores = availableResources.cores
+      availableResources.subset(cores, Memory(s"${2*cores.value.toLong}g"))
+    }
+  }
+
+  // A variable task that takes four times as much memory in GB as available cores.
+  private val quadMemoryTask = new VariableResources {
+    override def pickResources(availableResources: ResourceSet) = {
+      val cores = availableResources.cores
+      availableResources.subset(cores, Memory(s"${4*cores.value.toLong}g"))
+    }
+  }
+
+  // A variable task that always takes the available cores and 2g of memory.
+  private val twoGbTask = new VariableResources {
+    override def pickResources(availableResources: ResourceSet) = availableResources.subset(availableResources.cores, Memory("2g"))
+  }
+
+  "Schedulable.minCores" should "work with fixed resources" in {
+    fixedTask.requires(1, "2g").minCores().value.value shouldBe 1
+    fixedTask.requires(2, "2g").minCores().value.value shouldBe 2
+    fixedTask.requires(2, "2g").minCores(end=Cores(1)) shouldBe 'empty
+    fixedTask.requires(2, "2g").minCores(start=Cores(1), end=Cores(2), step=Cores(2)) shouldBe 'empty
+  }
+
+  it should "work with variable resources" in {
+    doubleMemoryTask.minCores(end=Cores(1)).value.value shouldBe 1
+    doubleMemoryTask.minCores(start=Cores(2), end=Cores(2), step=Cores(1)).value.value shouldBe 2
+    doubleMemoryTask.minCores(start=Cores(3), end=Cores(2), step=Cores(1)) shouldBe 'empty
+  }
+
+  "Schedulable.minMemory" should "work with fixed resources" in {
+    fixedTask.requires(1, "2g").minMemory().value shouldBe Memory("2g")
+    fixedTask.requires(2, "2g").minMemory().value shouldBe Memory("2g")
+    fixedTask.requires(2, "2g").minMemory(end=Memory("1g")) shouldBe 'empty
+    fixedTask.requires(2, "2g").minMemory(start=Memory("1g"), end=Memory("2g"), step=Memory("2g")) shouldBe 'empty
+  }
+
+  it should "work with variable resources" in {
+    twoGbTask.minMemory().value.value shouldBe Memory("2g").value
+    twoGbTask.minMemory(end=Memory("1g"), step=Memory("256m")) shouldBe 'empty
+    twoGbTask.minMemory(end=Memory("2g"), step=Memory("256m")).value.value shouldBe Memory("2g").value
+    twoGbTask.minMemory(start=Memory("1g"), end=Memory("2g"), step=Memory("1g")).value.value shouldBe Memory("2g").value
+    twoGbTask.minMemory(start=Memory("3g"), end=Memory("2g"), step=Memory("1g")) shouldBe 'empty
+  }
+
+  "Schedulable.minCoresAndMemory" should "work with fixed resources" in {
+    fixedTask.requires(2, "2g").minCoresAndMemory(memoryPerCore=Memory("1g")).value shouldBe ResourceSet(Cores(2), Memory("2g"))
+    fixedTask.requires(2, "1g").minCoresAndMemory(memoryPerCore=Memory("512m")).value shouldBe ResourceSet(Cores(2), Memory("1g"))
+    fixedTask.requires(2, "1g").minCoresAndMemory(memoryPerCore=Memory(Memory("1m").value / 2)) shouldBe 'empty
+  }
+
+  it should "work with variable resources" in {
+    doubleMemoryTask.minCoresAndMemory(memoryPerCore=Memory("4g")).value shouldBe ResourceSet(Cores(1), Memory("2g"))
+    doubleMemoryTask.minCoresAndMemory(memoryPerCore=Memory("2g")).value shouldBe ResourceSet(Cores(1), Memory("2g"))
+    doubleMemoryTask.minCoresAndMemory(memoryPerCore=Memory("1g")) shouldBe 'empty
+
+    quadMemoryTask.minCoresAndMemory(memoryPerCore=Memory("4g")).value shouldBe ResourceSet(Cores(1), Memory("4g"))
+    quadMemoryTask.minCoresAndMemory(memoryPerCore=Memory("2g")) shouldBe 'empty
+    quadMemoryTask.minCoresAndMemory(memoryPerCore=Memory("1g")) shouldBe 'empty
+  }
+
+  "Schedulable.minResources" should "work with fixed resources" in {
+    fixedTask.requires(1, "2g").minResources().value shouldBe ResourceSet(Cores(1), Memory("2g"))
+    fixedTask.requires(2, "24g").minResources().value shouldBe ResourceSet(Cores(2), Memory("24g"))
+    fixedTask.requires(2, "24g").minResources(maximumResources=ResourceSet(Cores(1), Memory("24g"))) shouldBe 'empty
+  }
+
+  it should "work with variable resources" in {
+    twoGbTask.minResources().value shouldBe ResourceSet(Cores(1), Memory("2g"))
+    twoGbTask.minResources(ResourceSet(Cores(2), Memory("2g"))).value shouldBe ResourceSet(Cores(1), Memory("2g"))
+    twoGbTask.minResources(ResourceSet(Cores(2), Memory("1g"))).value shouldBe ResourceSet(Cores(2), Memory("2g"))
+    twoGbTask.minResources(ResourceSet(Cores(2), Memory("1023m"))) shouldBe 'empty
+
+    doubleMemoryTask.minResources().value shouldBe ResourceSet(Cores(1), Memory("2g"))
+    doubleMemoryTask.minResources(ResourceSet(Cores(2), Memory("1g"))) shouldBe 'empty
+
+    quadMemoryTask.minResources().value shouldBe ResourceSet(Cores(1), Memory("4g"))
+    quadMemoryTask.minResources(ResourceSet(Cores(1), Memory("4g"))).value shouldBe ResourceSet(Cores(1), Memory("4g"))
+    quadMemoryTask.minResources(ResourceSet(Cores(1), Memory("3g"))) shouldBe 'empty
+  }
+}


### PR DESCRIPTION
This is used when a VariableResources task cannot be scheduled, and we'd like to know the minimum amount of resources it needs.

@tfenne I should add some tests, but I wanted to see what you thought.  I could also try a search on the diagonal too, but I thought that was overkill.