### PR TITLE
Small tweaks to how collection options & default values are output.

### DIFF
--- a/sopt/src/main/scala/dagr/sopt/cmdline/ClpArgumentDefinitionPrinting.scala
+++ b/sopt/src/main/scala/dagr/sopt/cmdline/ClpArgumentDefinitionPrinting.scala
@@ -24,11 +24,13 @@
 
 package dagr.sopt.cmdline
 
+import java.util
+
 import dagr.commons.reflect.ReflectionUtil
 import dagr.sopt.util._
 import dagr.commons.util.StringUtil
 
-import scala.util.{Success, Failure}
+import scala.util.{Failure, Success}
 
 object ClpArgumentDefinitionPrinting {
 
@@ -80,7 +82,7 @@ object ClpArgumentDefinitionPrinting {
     val desciption = (argumentDefinition.minElements, argumentDefinition.maxElements) match {
       case (0, Integer.MAX_VALUE) => "*"
       case (1, Integer.MAX_VALUE) => "+"
-      case (m, n)                 => s"{$m, $n}"
+      case (m, n)                 => s"{${m}..${n}}"
     }
     Some(desciption)
   }
@@ -93,12 +95,14 @@ object ClpArgumentDefinitionPrinting {
     *  d) There is a default, but it's an empty set
     */
   private[cmdline] def makeDefaultValueString(value : Option[_]) : String = {
+    import scala.collection.JavaConversions.iterableAsScalaIterable
     val v = value match {
       case None          => ""
       case Some(None)    => ""
       case Some(Nil)     => ""
       case Some(s) if Set.empty == s => ""
-      case Some(c) if c.isInstanceOf[java.util.Collection[_]] && c.asInstanceOf[java.util.Collection[_]].isEmpty => ""
+      case Some(c) if c.isInstanceOf[util.Collection[_]]  => c.asInstanceOf[util.Collection[_]].mkString(", ")
+      case Some(t) if t.isInstanceOf[Traversable[_]]      => t.asInstanceOf[Traversable[_]].mkString(", ")
       case Some(Some(x)) => x.toString
       case Some(x)       => x.toString
     }

--- a/sopt/src/test/scala/dagr/sopt/cmdline/ClpArgumentDefinitionPrintingTest.scala
+++ b/sopt/src/test/scala/dagr/sopt/cmdline/ClpArgumentDefinitionPrintingTest.scala
@@ -58,7 +58,7 @@ class ClpArgumentDefinitionPrintingTest extends UnitSpec with BeforeAndAfterAll 
     makeDefaultValueString(Some(Some("Value"))) shouldBe "[Default: Value]. "
     makeDefaultValueString(Some("Value")) shouldBe "[Default: Value]. "
     makeDefaultValueString(Some(Some(Some("Value")))) shouldBe "[Default: Some(Value)]. "
-    makeDefaultValueString(Some(List("A", "B", "C"))) shouldBe "[Default: List(A, B, C)]. "
+    makeDefaultValueString(Some(List("A", "B", "C"))) shouldBe "[Default: A, B, C]. "
   }
 
   private def printArgumentUsage(name: String, shortName: String, theType: String,


### PR DESCRIPTION
@nh13 Small change because it was bothering me how Collection/Traversable arguments were output in the usage.  Two changes:

1. The more important one, to how default values are output, so it drops the `List()` or `Set()` wrapper and outputs `A, B, C` instead of `List(A, B, C)`.
2. Outputting the range in a way I think is more understandable to those who aren't intimately familiar with regex details.  So `Int{1, 3}` is not `Int{1-3}`.  I'd also be happy with `Int{1..3}` if you thought that was clearer.

I was also tempted to write it as `Int[1-3]` using square brackets, but thought that might be confusing given the use of square brackets for optional values.