### PR TITLE
Added ability to use triple-quoted, margined strings for argument docs.

### DIFF
--- a/sopt/src/main/scala/dagr/sopt/cmdline/ClpReflectiveBuilder.scala
+++ b/sopt/src/main/scala/dagr/sopt/cmdline/ClpReflectiveBuilder.scala
@@ -149,7 +149,7 @@ private[sopt] class ClpArgument(declaringClass: Class[_],
   lazy val isSensitive: Boolean = annotation.exists(_.sensitive())
   lazy val longName: String     = if (annotation.isDefined && annotation.get.name.nonEmpty) annotation.get.name else StringUtil.camelToGnu(name)
   lazy val shortName: String    = annotation.map(_.flag()).getOrElse("")
-  lazy val doc: String          = annotation.map(_.doc()).getOrElse("")
+  lazy val doc: String          = annotation.map(_.doc().stripMargin.replace('\n', ' ')).getOrElse("")
   lazy val isCommon: Boolean    = annotation.exists(_.common())
   lazy val minElements: Int     = if (isCollection) {
     annotation.map(_.minElements).getOrElse(1)

--- a/sopt/src/main/scala/dagr/sopt/cmdline/ClpReflectiveBuilder.scala
+++ b/sopt/src/main/scala/dagr/sopt/cmdline/ClpReflectiveBuilder.scala
@@ -149,7 +149,7 @@ private[sopt] class ClpArgument(declaringClass: Class[_],
   lazy val isSensitive: Boolean = annotation.exists(_.sensitive())
   lazy val longName: String     = if (annotation.isDefined && annotation.get.name.nonEmpty) annotation.get.name else StringUtil.camelToGnu(name)
   lazy val shortName: String    = annotation.map(_.flag()).getOrElse("")
-  lazy val doc: String          = annotation.map(_.doc().stripMargin.replace('\n', ' ')).getOrElse("")
+  lazy val doc: String          = annotation.map(_.doc().stripMargin.replace('\n', ' ').trim).getOrElse("")
   lazy val isCommon: Boolean    = annotation.exists(_.common())
   lazy val minElements: Int     = if (isCollection) {
     annotation.map(_.minElements).getOrElse(1)

--- a/sopt/src/test/scala/dagr/sopt/cmdline/ClpArgumentTest.scala
+++ b/sopt/src/test/scala/dagr/sopt/cmdline/ClpArgumentTest.scala
@@ -40,6 +40,11 @@ object ClpArgumentTest {
   case class SeqWithDefaults(@arg var aSeq: Seq[_] = Seq(1, 2, 3))
   case class NoAnnotation(var aVar: Boolean = false)
   case class NoAnnotationNoDefault(var Boolean: Int)
+  case class LongArgDoc(@arg(doc=
+    """This is
+      |supposed to
+      |be wrapped.
+    """) foo: String)
 }
 
 class ClpArgumentTest extends UnitSpec with OptionValues {
@@ -210,6 +215,11 @@ class ClpArgumentTest extends UnitSpec with OptionValues {
     argument.setArgument("false")
     argument.value.get should be(false.asInstanceOf[Any])
     argument.value.get.asInstanceOf[Boolean] should be(false)
+  }
+
+  it should "correctly un-wrap argument docs that use multi-line syntax" in {
+    val argument = makeClpArgument(classOf[LongArgDoc], defaultValue="foo")
+    argument.doc shouldBe "This is supposed to be wrapped."
   }
 
   it should "throw an IllegalStateException when creating an argument without an annotation with no default" in {


### PR DESCRIPTION
@nh13 the scaladoc process doesn't like @arg annotations with `doc="foo" + "bar"` which is the obvious way to type out longer docs.  This change allows `doc=` to use the same format as we do for `@clp(description)` but removes line breaks and replaces them with spaces.