### PR TITLE
Added a minimumAf parameter to the MuTect 1 task.

### DIFF
--- a/tasks/src/main/scala/dagr/tasks/gatk/Mutect1.scala
+++ b/tasks/src/main/scala/dagr/tasks/gatk/Mutect1.scala
@@ -42,6 +42,7 @@ class Mutect1(val tumorBam: PathToBam,
               val callStatsOutput: Path,
               val tumorSampleName: String = "tumor",
               val normalSampleName: String = "normal",
+              val minimumAf: Option[Double] = None,
               val fractionContamination: Double = 0,
               val maxAltAlleleInNormalFraction: Double = 0.03,
               val maxAltAlleleInNormalCount: Int = 5, // MuTect Default = 2
@@ -56,6 +57,7 @@ class Mutect1(val tumorBam: PathToBam,
     normalBam.foreach(buffer.append("--input_file:normal", _))
     buffer.append("--tumor_sample_name", tumorSampleName)
     buffer.append("--normal_sample_name", normalSampleName)
+    minimumAf.foreach(buffer.append("--minimum_mutation_cell_fraction", _))
     buffer.append("--fraction_contamination", fractionContamination)
     buffer.append("--max_alt_allele_in_normal_fraction", maxAltAlleleInNormalFraction)
     buffer.append("--max_alt_alleles_in_normal_count", maxAltAlleleInNormalCount)


### PR DESCRIPTION
@nh13: Trivial PR here.  I named the parameter `minimumAf` to mirror the same parameter in our VarDictJava tasks, as opposed to mimicing MuTects name for the parameter.