### PR TITLE
Dependency DSL now works on Options!

### DIFF
--- a/core/src/main/scala/dagr/core/tasksystem/Dependable.scala
+++ b/core/src/main/scala/dagr/core/tasksystem/Dependable.scala
@@ -68,7 +68,7 @@ trait Dependable {
 
 /** An object that can be implicitly converted to from a None when using Option[Dependable]. */
 object EmptyDependable extends Dependable {
-  /** Converts an Option[Dependable] to a Dependable when needed. */
+  /** Converts an Option[Dependable] to a Dependable when needed. Linked to from [[DagrDef]] to accessibility. */
   implicit def optionDependableToDependable(maybe: Option[Dependable]): Dependable = maybe match {
     case Some(d) => d
     case None    => EmptyDependable

--- a/core/src/test/scala/dagr/core/tasksystem/DependableTest.scala
+++ b/core/src/test/scala/dagr/core/tasksystem/DependableTest.scala
@@ -1,0 +1,56 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package dagr.core.tasksystem
+
+import dagr.commons.util.UnitSpec
+
+class DependableTest extends UnitSpec {
+  import EmptyDependable.optionDependableToDependable // import the implicit
+
+  val X = new ShellCommand("echo", "hello", "world")
+  val Y = new ShellCommand("echo", "hello", "world")
+  val Z = new ShellCommand("echo", "hello", "world")
+
+  "Dependable.==>" should "return the real task when invoked on a task and a None" in {
+    (X ==> None) shouldBe X
+    (None ==> X) shouldBe X
+    (Some(X) ==> None) shouldBe X
+    (None ==> Some(X)) shouldBe X
+  }
+
+  it should "collapse things out of the chain when there are Nones in the chain" in {
+    (X ==> Y) shouldBe DependencyChain(X, Y)
+    (X ==> None ==> None ==> Some(Y)) shouldBe DependencyChain(X, Y)
+    (None ==> Some(X) ==> None ==> Some(Y)) shouldBe DependencyChain(X, Y)
+  }
+
+  "Dependable.::" should "accept options and drop Nones when amassing a group" in {
+    (None :: X :: None) shouldBe X
+    (None :: Some(X) :: None) shouldBe X
+    (None :: X) shouldBe X
+    (X :: None) shouldBe X
+    (X :: None :: None :: Some(Y) :: None) shouldBe DependencyGroup(X, Y)
+  }
+}

--- a/tasks/src/main/scala/dagr/tasks/DagrDef.scala
+++ b/tasks/src/main/scala/dagr/tasks/DagrDef.scala
@@ -25,6 +25,8 @@
 
 package dagr.tasks
 
+import dagr.core.tasksystem.{Dependable, EmptyDependable}
+
 /**
   * Object that is designed to be imported with `import DagrDef._` in any/all classes
   * much like the way that scala.PreDef is imported in all files automatically.
@@ -65,4 +67,6 @@ object DagrDef {
   /** A String that represents the prefix or basename of a filename. */
   type FilenamePrefix = String
 
+  /** Implicit that will convert an Option[Dependable] to a Dependable when needed. */
+  implicit def optionDependableToDependable(maybe: Option[Dependable]): Dependable = EmptyDependable.optionDependableToDependable(maybe)
 }


### PR DESCRIPTION
@nh13 This PR is a touch more involved, but I'd love to get your feedback.  I got tired of having to do things like:

```scala
if (x) new Task(...) else NoOpInJvmTask(...)
```

in order to keep the dependency DSL happy.  The goal here is to allow `Option[Dependable]` to function as a dependable.  `None`s are effectively flattened out - i.e. `x ==> None == y` is flattened to `x ==> y` and `x :: None :: y` is flattened to `x :: y`.

This allows a much more natural approach like:

```scala
val makeFoo = foo.map(f => new MakeFoo(in=x, out=f))
val qcFoo = foo.map(f => new QcFoo(in=f, out=qc))
root ==> makeFoo ==> qcFoo
```

The implicit is only required to make things work when an `Option[Dependable]` shows up at the end of a chain (either lhs for `==>` or rhs for `::` due to associativity.  I.e.

```scala
// Works without implicit
root ==> None ==> Some(task) ==> None
root ==> (None :: Some(task) :: otherTask)

// Works only with the implicit
Some(task) ==> otherTask
root ==> (task :: Some(otherTask))
```