### PR TITLE
Fix for minor bug where more dependencies were getting created than necessary.

### DIFF
--- a/core/src/main/scala/dagr/core/tasksystem/Pipeline.scala
+++ b/core/src/main/scala/dagr/core/tasksystem/Pipeline.scala
@@ -44,9 +44,9 @@ abstract class Pipeline(val outputDirectory: Option[Path] = None,
     /** Breaks the dependency link between this dependable and the provided Task. */
     override def !=> (other: Dependable): Unit = other.headTasks.foreach(tasks.remove)
 
-    override def headTasks: Traversable[Task] = ???
-    override def tailTasks: Traversable[Task] = ???
-    override def allTasks: Traversable[Task]  = ???
+    override def headTasks: Traversable[Task] = Pipeline.this.headTasks
+    override def tailTasks: Traversable[Task] = Pipeline.this.tailTasks
+    override def allTasks: Traversable[Task]  = Pipeline.this.allTasks
   }
 
   /**

--- a/core/src/main/scala/dagr/core/tasksystem/Pipeline.scala
+++ b/core/src/main/scala/dagr/core/tasksystem/Pipeline.scala
@@ -39,13 +39,14 @@ abstract class Pipeline(val outputDirectory: Option[Path] = None,
   /** A name exposed to sub-classes that can be treated like a Task, to add root tasks. */
   val root = new Dependable {
     /** Must be implemented to handle the addition of a dependent. */
-    override def addDependent(dependent: Dependable): Unit = dependent.toTasks.foreach(tasks.add)
+    override def addDependent(dependent: Dependable): Unit = dependent.headTasks.foreach(tasks.add)
 
     /** Breaks the dependency link between this dependable and the provided Task. */
-    override def !=> (other: Dependable): Unit = other.toTasks.foreach(tasks.remove)
+    override def !=> (other: Dependable): Unit = other.headTasks.foreach(tasks.remove)
 
-    /** Returns none as the symbolic `root` should never appear on the right hand side of a `==>`. */
-    override private[tasksystem] def toTasks: Traversable[Task] = None
+    override def headTasks: Traversable[Task] = ???
+    override def tailTasks: Traversable[Task] = ???
+    override def allTasks: Traversable[Task]  = ???
   }
 
   /**

--- a/core/src/main/scala/dagr/core/tasksystem/Task.scala
+++ b/core/src/main/scala/dagr/core/tasksystem/Task.scala
@@ -172,24 +172,25 @@ trait Task extends Dependable {
   protected[core] def tasksDependingOnThisTask: Traversable[Task] = this.dependedOnByTasks.toList
 
   /** Must be implemented to handle the addition of a dependent. */
-  override def addDependent(dependent: Dependable): Unit = dependent.toTasks.foreach(t => {
+  override def addDependent(dependent: Dependable): Unit = dependent.headTasks.foreach(t => {
       t.dependsOnTasks += this
       this.dependedOnByTasks += t
     })
 
   /** Removes this as a dependency for other */
-  override def !=>(other: Dependable): Unit = other.toTasks.foreach(_.removeDependency(this))
+  override def !=>(other: Dependable): Unit = other.headTasks.foreach(_.removeDependency(this))
 
-  /** Implementation of method from Dependable, to return the task as the set of Tasks represented. */
-  override private[tasksystem] def toTasks: Traversable[Task] = Some(this)
+  override def headTasks: Traversable[Task] = Seq(this)
+  override def tailTasks: Traversable[Task] = Seq(this)
+  override def allTasks: Traversable[Task]  = Seq(this)
 
   /**
-   * Removes a dependency by removing the supplied task from the list of dependencies for this task
-   * and removing this from the list of tasks depending on "task".
-   *
-   * @param task a task on which this task depends
-   * @return true if a dependency existed and was removed, false otherwise
-   */
+     * Removes a dependency by removing the supplied task from the list of dependencies for this task
+     * and removing this from the list of tasks depending on "task".
+     *
+     * @param task a task on which this task depends
+     * @return true if a dependency existed and was removed, false otherwise
+     */
   def removeDependency(task: Task): Boolean = {
     if (this.dependsOnTasks.contains(task)) {
       this.dependsOnTasks -= task

--- a/core/src/test/scala/dagr/core/tasksystem/DependableTest.scala
+++ b/core/src/test/scala/dagr/core/tasksystem/DependableTest.scala
@@ -124,4 +124,14 @@ class DependableTest extends UnitSpec {
     j.tasksDependedOn should contain theSameElementsAs Seq(i)
     k.tasksDependedOn should contain theSameElementsAs Seq(i)
   }
+
+  "Pipeline.root" should "return the same things as Pipeline from the *tasks methods" in {
+    val pipeline = new Pipeline() {
+      override def build() = root ==> (A :: B :: C) ==> (X :: Y :: Z)
+    }
+
+    pipeline.root.headTasks shouldBe pipeline.headTasks
+    pipeline.root.tailTasks shouldBe pipeline.tailTasks
+    pipeline.root.allTasks  shouldBe pipeline.allTasks
+  }
 }

--- a/core/src/test/scala/dagr/core/tasksystem/DependableTest.scala
+++ b/core/src/test/scala/dagr/core/tasksystem/DependableTest.scala
@@ -70,11 +70,11 @@ class DependableTest extends UnitSpec {
   }
 
   it should "build groups of tasks" in {
-    (X :: Y :: Z).toTasks should contain theSameElementsAs Seq(X, Y, Z)
-    (None :: Some(X) :: None :: Y :: Some(Z)).toTasks should contain theSameElementsAs Seq(X, Y, Z)
+    (X :: Y :: Z).allTasks should contain theSameElementsAs Seq(X, Y, Z)
+    (None :: Some(X) :: None :: Y :: Some(Z)).allTasks should contain theSameElementsAs Seq(X, Y, Z)
   }
 
   "EmptyDependable.toTasks" should "always return no tasks" in {
-    (None :: None :: None).toTasks shouldBe empty
+    (None :: None :: None).allTasks shouldBe empty
   }
 }

--- a/core/src/test/scala/dagr/core/tasksystem/DependableTest.scala
+++ b/core/src/test/scala/dagr/core/tasksystem/DependableTest.scala
@@ -29,13 +29,13 @@ import dagr.commons.util.UnitSpec
 class DependableTest extends UnitSpec {
   import EmptyDependable.optionDependableToDependable // import the implicit
 
-  class TrivialTask extends UnitTask with FixedResources { override def toString: String = name }
-  val A = new TrivialTask().withName("A")
-  val B = new TrivialTask().withName("B")
-  val C = new TrivialTask().withName("C")
-  val X = new TrivialTask().withName("X")
-  val Y = new TrivialTask().withName("Y")
-  val Z = new TrivialTask().withName("Z")
+  case class TrivialTask(x: String) extends UnitTask with FixedResources { override def toString: String = x }
+  val A = TrivialTask("A")
+  val B = TrivialTask("B")
+  val C = TrivialTask("C")
+  val X = TrivialTask("X")
+  val Y = TrivialTask("Y")
+  val Z = TrivialTask("Z")
 
   "Dependable.==>" should "return the real task when invoked on a task and a None" in {
     (X ==> None) shouldBe X
@@ -74,7 +74,54 @@ class DependableTest extends UnitSpec {
     (None :: Some(X) :: None :: Y :: Some(Z)).allTasks should contain theSameElementsAs Seq(X, Y, Z)
   }
 
-  "EmptyDependable.toTasks" should "always return no tasks" in {
-    (None :: None :: None).allTasks shouldBe empty
+  "EmptyDependable" should "always return Nil from it's *tasks methods" in {
+    (None ==> None).headTasks shouldBe Nil
+    (None ==> None).tailTasks shouldBe Nil
+    (None ==> None).allTasks  shouldBe Nil
+  }
+
+  "Dependable.!=>" should "remove existing dependencies" in {
+    val Seq(a, b, c, d, e, f) = "abcdef".map(ch => TrivialTask(ch.toString))
+    (a :: b :: c) ==> (d :: e :: f)
+    a !=> d
+    (b :: c) !=> (d :: e)
+
+    a.tasksDependingOnThisTask should contain theSameElementsAs Seq(e, f)
+    b.tasksDependingOnThisTask should contain theSameElementsAs Seq(f)
+    c.tasksDependingOnThisTask should contain theSameElementsAs Seq(f)
+  }
+
+  "Dependable" should "wire together a whole mess of tasks" in {
+    val Seq(a, b, c, d, e, f, g, h, i, j, k) = "abcdefghijk".map(ch => TrivialTask(ch.toString))
+    val bcd   = b ==> c ==> d
+    val abcde = a ==> bcd ==> Some(e)
+    val fgh   = None :: Some(f) :: g :: Some(h) :: None
+    val ijk   = i ==> (j :: k)
+
+    abcde ==> fgh ==> ijk // should be a -> b -> c -> d -> e -> (f :: g :: h) -> i -> (j :: k)
+
+    a.tasksDependingOnThisTask should contain theSameElementsAs Seq(b)
+    b.tasksDependingOnThisTask should contain theSameElementsAs Seq(c)
+    c.tasksDependingOnThisTask should contain theSameElementsAs Seq(d)
+    d.tasksDependingOnThisTask should contain theSameElementsAs Seq(e)
+    e.tasksDependingOnThisTask should contain theSameElementsAs Seq(f, g, h)
+    f.tasksDependingOnThisTask should contain theSameElementsAs Seq(i)
+    g.tasksDependingOnThisTask should contain theSameElementsAs Seq(i)
+    h.tasksDependingOnThisTask should contain theSameElementsAs Seq(i)
+    i.tasksDependingOnThisTask should contain theSameElementsAs Seq(j, k)
+    j.tasksDependingOnThisTask should contain theSameElementsAs Seq()
+    k.tasksDependingOnThisTask should contain theSameElementsAs Seq()
+
+    a.tasksDependedOn should contain theSameElementsAs Seq()
+    b.tasksDependedOn should contain theSameElementsAs Seq(a)
+    c.tasksDependedOn should contain theSameElementsAs Seq(b)
+    d.tasksDependedOn should contain theSameElementsAs Seq(c)
+    e.tasksDependedOn should contain theSameElementsAs Seq(d)
+    f.tasksDependedOn should contain theSameElementsAs Seq(e)
+    g.tasksDependedOn should contain theSameElementsAs Seq(e)
+    h.tasksDependedOn should contain theSameElementsAs Seq(e)
+    i.tasksDependedOn should contain theSameElementsAs Seq(f, g, h)
+    j.tasksDependedOn should contain theSameElementsAs Seq(i)
+    k.tasksDependedOn should contain theSameElementsAs Seq(i)
   }
 }


### PR DESCRIPTION
Previously `a ==> (b ==> c ==> d)` would create `a ==> b`, `a ==> c` and `a ==> d` instead of just a ==> b.  This didn't cause any errors, but is unnecessary, and confusing when debugging.