### PR TITLE
Type mismatch when constructing an object.

### DIFF
--- a/commons/src/main/scala/dagr/commons/reflect/ReflectionUtil.scala
+++ b/commons/src/main/scala/dagr/commons/reflect/ReflectionUtil.scala
@@ -303,7 +303,7 @@ object ReflectionUtil {
     * the creation of and packaging into collections as necessary.
     */
   private[reflect] def typedValueFromString(resultType: Class[_], unitType: Class[_], value: String*): Try[Any] = Try {
-    if (ReflectionUtil.isCollectionClass(resultType)) {
+    if (ReflectionUtil.isCollectionClass(resultType) && resultType != unitType) {
       val typedValues = if (value.length == 1 && value.head.toLowerCase == SpecialEmptyOrNoneToken) {
         Seq.empty
       }


### PR DESCRIPTION
@tfenne This relates to using an fgbio `ReadStructure` as a type for a CLP argument or member of a metric, where we add in a secondary constructor to `ReadStructure`: 
```
  def this(readStructure: String) = this(ReadStructure.apply(readStructure=readStructure))
```
Without this constructor, `ReflectionUtil` complains of no `String` constructor (but the `apply` method!).

What's interesting is the call to `ReflectionUtil.constructFromString` is passed in `classOf[ReadStructure]` for both the `resultType` and `unitType` respectively.  Since `ReadStructure` is a `immutable.Seq`, it tries to build a collection of type `ReadStructure` with elements of type `ReadStructure` (doh!).  I therefore suspect that the `ReflectiveBuilder`'s `argumentLookup` is wrong for the `Argument` for the `ReadStructure`, namely that the `unitType` is set incorrectly to `ReadStructure` in `ReflectiveBuilder`'s `extractParameterInformation` method.  I think `unitType` should be of type `ReadSegment`.  I don't know how to fix that.

Even if it did get that far, it will barf trying to pass the read structure string (ex. `8B150T`) to a non-existent constructor for a single read segment (there are two in that example string), so we'll get the wrong behavior anyhow.  

I suppose what we need is some way to construct a collection but bypass the various collection building logic in `typedValueFromString` and just invoke the collection's string constructor.  Perhaps we just check for a string constructor on a collection and proceed from there?


