### PR TITLE
Pipelines can now control printing their clp args (if they are clps).

### DIFF
--- a/core/src/main/scala/dagr/core/config/Configuration.scala
+++ b/core/src/main/scala/dagr/core/config/Configuration.scala
@@ -54,6 +54,7 @@ object Configuration extends ConfigurationLike {
     val LogDirectory    = "dagr.log-directory"
     val SystemCores     = "dagr.system-cores"
     val SystemMemory    = "dagr.system-memory"
+    val PrintArgs       = "dagr.print-args"
   }
 
   // The global configuration instance

--- a/sopt/src/main/scala/dagr/sopt/cmdline/CommandLineProgramParser.scala
+++ b/sopt/src/main/scala/dagr/sopt/cmdline/CommandLineProgramParser.scala
@@ -280,15 +280,16 @@ class CommandLineProgramParser[T](val targetClass: Class[T]) extends CommandLine
   }
 
   /** Gets the command line assuming `parseTasks` has been called */
-  def commandLine(printCommon: Boolean = true): String = {
+  def commandLine(): String = {
     val argumentList = this.argumentLookup.ordered.filterNot(_.hidden)
     val toolName: String = targetName
     val commandLineString: StringBuilder = new StringBuilder
 
-    commandLineString.append(argumentList.filter( _.hasValue).filter(!_.isSpecial).map(_.toCommandLineString).mkString(" "))
-    commandLineString.append(argumentList.filter(!_.hasValue).filter(!_.isSpecial).map(_.toCommandLineString).mkString(" "))
+    commandLineString.append(argumentList.filter( _.hasValue).filterNot(_.isSpecial).map(_.toCommandLineString).mkString(" "))
+    commandLineString.append(argumentList.filter(!_.hasValue).filterNot(_.isSpecial).map(_.toCommandLineString).mkString(" "))
 
-    s"$toolName ${commandLineString.toString}"
+    if (commandLineString.isEmpty) toolName
+    else s"$toolName $commandLineString"
   }
 
   /**


### PR DESCRIPTION


@tfenne I waffled on a bunch of ways and places in which to implement this, including a mix-in trait for `Pipeline` (ex. `PrintPipelineArgs`) versus the current method _in_ `Pipeline`, having the parsing code do the actual printing versus the `DagrCoreMain`.  I found this was the easiest.