### PR TITLE
Removed setting of name in SimpleInJvmTask that replicates default behaviour.

### DIFF
--- a/core/src/main/scala/dagr/core/tasksystem/SimpleInJvmTask.scala
+++ b/core/src/main/scala/dagr/core/tasksystem/SimpleInJvmTask.scala
@@ -43,7 +43,6 @@ object SimpleInJvmTask {
   * uses the raising of exceptions or lack thereof to indicate failure and success.
   */
 abstract class SimpleInJvmTask extends InJvmTask with FixedResources {
-  name = "SimpleInJvmTask"
   requires(Cores(1), Memory("32M"))
 
   /** Executes run() and returns 0 if no exception is thrown, otherwise 1. */


### PR DESCRIPTION
@nh13 Trivial PR here.  This gets rid of the assignment in SimpleInJvmTask which clobbers the `name = getClass.getSimpleName` up in `Task`.  For `SimpleInJvmTask` itself the result is identical.  For children of `SimpleInJvmTask` they now get _their_ class name as their name instead of just `SimpleInJvmTask`.