### PR TITLE
Fixed JvmOutOfMemoryRetry so that it can find tokens that are partial…

### DIFF
--- a/core/src/main/scala/dagr/core/tasksystem/Retry.scala
+++ b/core/src/main/scala/dagr/core/tasksystem/Retry.scala
@@ -118,20 +118,13 @@ trait MultipleRetry extends Retry with LazyLogging {
   }
 }
 
-object JvmRanOutOfMemory {
-  val outOfMemoryTokens: List[String] = List ("OutOfMemory", "you did not provide enough memory to run this program")
-}
-
 /** Determines if a the task failed because it ran out of memory by looking for various strings in the log file. */
 trait JvmRanOutOfMemory extends MemoryRetry {
-  protected def outOfMemoryTokens: List[String] = JvmRanOutOfMemory.outOfMemoryTokens
+  /** A list of tokens that are looked for in the log file of a process by the default [[ranOutOfMemory]]. */
+  def outOfMemoryTokens: List[String] =  List ("OutOfMemory", "you did not provide enough memory to run this program")
 
   override protected[core] def ranOutOfMemory(taskInfo: TaskExecutionInfo): Boolean = {
-    if (Files.exists(taskInfo.logFile)) {
-      Io.readLines(taskInfo.logFile).exists(outOfMemoryTokens.contains(_))
-    }
-    else {
-      false
-    }
+    Files.exists(taskInfo.logFile) &&
+      Io.readLines(taskInfo.logFile).exists(line => outOfMemoryTokens.exists(token => line.contains(token)))
   }
 }


### PR DESCRIPTION
… matches to lines.  Previously it requires that the token match the entire line, which never actually matched.

Also tidied up a little while I was in there.