### PR TITLE
Missing space in the printed command line string.

### DIFF
--- a/sopt/src/main/scala/dagr/sopt/cmdline/CommandLineProgramParser.scala
+++ b/sopt/src/main/scala/dagr/sopt/cmdline/CommandLineProgramParser.scala
@@ -283,11 +283,11 @@ class CommandLineProgramParser[T](val targetClass: Class[T]) extends CommandLine
   def commandLine(): String = {
     val argumentList = this.argumentLookup.ordered.filterNot(_.hidden)
     val toolName: String = targetName
-    val commandLineString: StringBuilder = new StringBuilder
-
-    commandLineString.append(argumentList.filter( _.hasValue).filterNot(_.isSpecial).map(_.toCommandLineString).mkString(" "))
-    commandLineString.append(argumentList.filter(!_.hasValue).filterNot(_.isSpecial).map(_.toCommandLineString).mkString(" "))
-
+    val commandLineString = argumentList
+      .filterNot(_.isSpecial)
+      .groupBy(!_.hasValue) // so that args with values come first
+      .flatMap { case (_, args) => args.map(_.toCommandLineString) }
+      .mkString(" ")
     if (commandLineString.isEmpty) toolName
     else s"$toolName $commandLineString"
   }


### PR DESCRIPTION
The command line string first has all options with values followed by all options without values. These two groups were not properly separated by a space.  Now they are!