### PR TITLE
Use the output prefix in CollectIlluminaBasecallingMetrics and Extrac…

### DIFF
--- a/tasks/src/main/scala/dagr/tasks/picard/CollectIlluminaBasecallingMetrics.scala
+++ b/tasks/src/main/scala/dagr/tasks/picard/CollectIlluminaBasecallingMetrics.scala
@@ -43,7 +43,7 @@ class CollectIlluminaBasecallingMetrics(basecallsDir: DirPath,
                                         lane: Int,
                                         barcodeFile: Option[FilePath] = None,
                                         readStructure: String,
-                                        prefix: Option[PathPrefix] = None,
+                                        override val prefix: Option[PathPrefix] = None,
                                         barcodesDir: Option[DirPath] = None
                                        ) extends PicardTask with PicardMetricsTask {
 

--- a/tasks/src/main/scala/dagr/tasks/picard/ExtractIlluminaBarcodes.scala
+++ b/tasks/src/main/scala/dagr/tasks/picard/ExtractIlluminaBarcodes.scala
@@ -52,7 +52,7 @@ class ExtractIlluminaBarcodes(basecallsDir: DirPath,
                               compressOutputs: Boolean = true,
                               minThreads: Int = 4,
                               maxThreads: Int = 16,
-                              prefix: Option[PathPrefix] = None
+                              override val prefix: Option[PathPrefix] = None
                              ) extends PicardTask with PicardMetricsTask with VariableResources {
 
   private val _barcodesDir: DirPath = prefix.map(_.getParent).getOrElse(basecallsDir)


### PR DESCRIPTION
…tIlluminaBarcodes

This is so we override `prefix` in `PicardTask`.