### PR TITLE
New task for SortBam.

### DIFF
--- a/tasks/src/main/scala/dagr/tasks/fgbio/SortBam.scala
+++ b/tasks/src/main/scala/dagr/tasks/fgbio/SortBam.scala
@@ -1,0 +1,48 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package dagr.tasks.fgbio
+
+import com.fulcrumgenomics.commons.io.Io
+import dagr.core.tasksystem.Pipe
+import dagr.tasks.DagrDef.PathToBam
+import dagr.tasks.DataTypes.SamOrBam
+
+import scala.collection.mutable.ListBuffer
+
+class SortBam(val in: PathToBam,
+              val out: PathToBam,
+              val sortOrder: Option[String],
+              val maxInMemory: Option[Int]
+             ) extends FgBioTask with Pipe[SamOrBam,SamOrBam] {
+
+  if (out == Io.StdOut) compressionLevel = Some(0)
+
+  override protected def addFgBioArgs(buffer: ListBuffer[Any]): Unit = {
+    buffer.append("-i", in)
+    buffer.append("-o", out)
+    sortOrder.foreach(so => buffer.append("-s", sortOrder))
+    maxInMemory.foreach(m => buffer.append("-m", m))
+  }
+}


### PR DESCRIPTION
I'm curious what your thoughts are @nh13  on how to handle the sort order param.  Dagr doesn't depend on `fgbio` currently, and I don't think we really want it to either.  So the enum isn't available.

The options as I see it are:

1. Take a String for sort order, which means that it'll always take all the values in fgbio (even if they get added to), but will also accept incorrect values
2. Make an enum here, but then if a sort order gets added in fgbio it has to get added here too