### PR TITLE
Removing project-specific build files.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -109,7 +109,8 @@ lazy val commonSettings = Seq(
   // See https://github.com/sbt/sbt/issues/653
   // and https://github.com/travis-ci/travis-ci/issues/3775
   javaOptions in Test += "-Xmx1G",
-  libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % "test->*" excludeAll ExclusionRule(organization="org.junit", name="junit")
+  libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % "test->*" excludeAll ExclusionRule(organization="org.junit", name="junit"),
+  assemblyJarName in assembly := s"${name.value}-${version.value}.jar"
 ) ++ Defaults.coreDefaultSettings
 
 ////////////////////////////////////////////////////////////////////////////////////////////////

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -1,1 +1,0 @@
-assemblyJarName in assembly := "dagr-core-" + version.value + ".jar"

--- a/pipelines/build.sbt
+++ b/pipelines/build.sbt
@@ -1,1 +1,0 @@
-assemblyJarName in assembly := "dagr-pipelines-" + version.value + ".jar"

--- a/tasks/build.sbt
+++ b/tasks/build.sbt
@@ -1,1 +1,0 @@
-assemblyJarName in assembly := "dagr-tasks-" + version.value + ".jar"


### PR DESCRIPTION
They are no longer needed as the assembly name can be set within the
top-level build file.