### PR TITLE
Updates to VarDictJava and VarDictJavaEndToEnd

### DIFF
--- a/tasks/src/main/scala/dagr/tasks/vc/VarDictJava.scala
+++ b/tasks/src/main/scala/dagr/tasks/vc/VarDictJava.scala
@@ -147,6 +147,8 @@ class VarDictJavaEndToEnd
   private val biasScript = BinDir.resolve("teststrandbias.R")
   private val vcfScript  = BinDir.resolve("var2vcf_valid.pl")
 
+  if (allSites) require(pileupMode, "pileup-mode is required when all-sites is used")
+
   def build(): Unit = {
     val tn = tumorName.getOrElse(VarDictJava.extractSampleName(bam=tumorBam))
     val dict = PathUtil.replaceExtension(ref, ".dict")


### PR DESCRIPTION
* support the -K option to include the count of Ns in the total depth: https://github.com/AstraZeneca-NGS/VarDictJava/pull/88

* support outputting all sites, including reference sites, not just sites with alternate alternate alleles.