### PR TITLE
ErrorRateByReadPosition does pileups, which require memory linear to …

### DIFF
--- a/tasks/src/main/scala/dagr/tasks/fgbio/ErrorRateByReadPosition.scala
+++ b/tasks/src/main/scala/dagr/tasks/fgbio/ErrorRateByReadPosition.scala
@@ -24,6 +24,7 @@
 
 package dagr.tasks.fgbio
 
+import dagr.core.tasksystem.{JvmRanOutOfMemory, MemoryDoublingRetry}
 import dagr.tasks.DagrDef.{PathPrefix, PathToBam, PathToFasta, PathToIntervals, PathToVcf}
 
 import scala.collection.mutable.ListBuffer
@@ -36,7 +37,7 @@ case class ErrorRateByReadPosition(in: PathToBam,
                                    includeDuplicates: Option[Boolean] = None,
                                    minMappingQuality: Option[Int] = None,
                                    minBaseQuality: Option[Int] = None
-                             ) extends FgBioTask {
+                             ) extends FgBioTask with MemoryDoublingRetry with JvmRanOutOfMemory {
 
   override protected def addFgBioArgs(buffer: ListBuffer[Any]): Unit = {
     buffer.append("-i", in)


### PR DESCRIPTION
…the depth.  Usually it runs just fine in 4G, but in very deep data it will run out of memory.

@nh13 Assuming you don't object to this tiny change can you just hit merge please?