### PR TITLE
Add tumor-normal calling mode to VarDictJavaEndToEnd

### DIFF
--- a/tasks/src/main/scala/dagr/tasks/vc/VarDictJava.scala
+++ b/tasks/src/main/scala/dagr/tasks/vc/VarDictJava.scala
@@ -261,33 +261,13 @@ private class Var2VcfValid(sampleName: String,
       |
       |`VarDictJava` performance scales linearly to sequencing depth, making it suitable for high coverage calling.
       |
-      |## The `VarDictJava` Workflow:
+      |See the `VarDictJava` documentation for more information:
       |
-      |1. Subset variant calling to the regions of interest provided in `bed`.
-      |2. For each segment in the interval file:
-      |    1. Find all variants:
-      |        - Skip non-passing filter reads.
-      |        - Skip unmapped reads.
-      |        - Skip a read if it does not overlap with the segment.
-      |        - Pre-process the CIGAR string (see https://github.com/AstraZeneca-NGS/VarDictJava#cigar-preprocessing-initial-realignment)
-      |        - For each non-matching position in the alignment, support an existing variant, or create a new variant.
-      |    2. Find structural variants.
-      |    3. Realign some of the variants using information about previously detected structural variation.
-      |    4. Calculate statistics for each variant.
-      |    5. Assign a type to each variant.
-      |    6. Output variants into an intermediate tabular format (`.var`) (see https://github.com/AstraZeneca-NGS/VarDictJava#output-columns)
-      |3. Perform a statistical test:
-      |    - For tumor-only calling, strand bias is tested.
-      |    - For tumor-normal calling, somatic candidacy is tested.
-      |4. Transform the intermediate tabular format to valid VCF output.
+      |  - https://github.com/AstraZeneca-NGS/VarDictJava
       |
       |## Sample Names
       |
       |The output sample names will be inferred from the first read group in the corresponding input BAM if not provided.
-      |
-      |See the `VarDictJava` documentation for more information:
-      |
-      |  - https://github.com/AstraZeneca-NGS/VarDictJava
     """",
   group = classOf[Pipelines]
 )

--- a/tasks/src/main/scala/dagr/tasks/vc/VarDictJava.scala
+++ b/tasks/src/main/scala/dagr/tasks/vc/VarDictJava.scala
@@ -36,6 +36,7 @@ import dagr.core.tasksystem.Pipes.PipeWithNoResources
 import dagr.core.tasksystem._
 import com.fulcrumgenomics.sopt.{arg, clp}
 import dagr.tasks.DagrDef._
+import dagr.tasks.DataTypes._
 import dagr.tasks.misc.DeleteFiles
 import dagr.tasks.picard.SortVcf
 import htsjdk.samtools.SamReaderFactory
@@ -61,11 +62,32 @@ object VarDictJava extends Configuration {
   /** Path to the VarDict submodule with a multitude of perl and R scripts. */
   val BinDir = RootDir.resolve("VarDict")
 
-  /** Path to the teststrandbias.R script in the VarDict submodule. */
+  /** Path to the `testsomatic.R` script in the VarDict submodule. */
+  val TestSomatic = BinDir.resolve("testsomatic.R")
+
+  /** Path to the `teststrandbias.R` script in the VarDict submodule. */
   val TestStrandBias = BinDir.resolve("teststrandbias.R")
 
-  /** Path to the var2vcf_valid.pl script in the VarDict submodule. */
+  /** Path to the `var2vcf_paired.pl` script in the VarDict submodule. */
+  val Var2VcfPaired = BinDir.resolve("var2vcf_paired.pl")
+
+  /** Path to the `var2vcf_valid.pl` script in the VarDict submodule. */
   val Var2VcfValid = BinDir.resolve("var2vcf_valid.pl")
+
+  /** The default minimum allele frequency for all VarDictJava calling and filtering tools. */
+  val MinimumAf: Double = 0.01
+
+  /** The minimum threads for `VarDictJava`. */
+  val MinimumThreads: Int = 1
+
+  /** The minimum threads for `VarDictJava`. */
+  val MaximumThreads: Int = 32
+
+  /** The default memory for `VarDictJava`. */
+  val DefaultMemory: Memory = Memory("8G")
+
+  /** Plain text tumor-normal separator. */
+  val TumorNormalSeparator: String = "|"
 
   /** Pulls a sample name out of a BAM file. */
   private[vc] def extractSampleName(bam: PathToBam): String = {
@@ -76,41 +98,53 @@ object VarDictJava extends Configuration {
 
 /** Runs VarDictJava to produce its intermediate tabular format. */
 private class VarDictJava(tumorBam: PathToBam,
+                          normalBam: Option[PathToBam],
                           bed: FilePath,
                           ref: PathToFasta,
                           tumorName: String,
-                          minimumAf: Double = 0.01,
+                          minimumAf: Double = VarDictJava.MinimumAf,
                           includeNonPf: Boolean = false,
                           minimumQuality: Option[Int] = None,
                           maximumMismatches: Option[Int] = None,
                           minimumAltReads: Option[Int] = None,
                           pileupMode: Boolean = false,
                           countNsInTotalDepth: Boolean = false,
-                          minThreads: Int = 1,
-                          maxThreads: Int = 32,
-                          memory: Memory = Memory("8G")
-                         ) extends ProcessTask with VariableResources with PipeOut[Any] {
+                          minThreads: Int = VarDictJava.MinimumThreads,
+                          maxThreads: Int = VarDictJava.MaximumThreads,
+                          memory: Memory = VarDictJava.DefaultMemory
+                         ) extends ProcessTask with VariableResources with PipeOut[Text] {
   name = "VarDictJava"
 
   override def pickResources(resources: ResourceSet): Option[ResourceSet] = {
     resources.subset(minCores = Cores(minThreads), maxCores = Cores(maxThreads), memory = memory)
   }
 
+  /** Format tumor/normal BAM paths into one argument by joining on the default separator. Defaults to the tumor BAM path. */
+  private def maybeJoinTumorNormalPaths(tumorBam: PathToBam, normalBam: Option[PathToBam]): String = {
+    normalBam match {
+      case None             => tumorBam.toString
+      case Some(_normalBam) => Seq(tumorBam.toString, _normalBam.toString).mkString(VarDictJava.TumorNormalSeparator)
+    }
+  }
+  
   override def args: Seq[Any] = {
     val buffer = new ListBuffer[Any]()
-    buffer.appendAll(List(VarDictJava.VarDictJava, "-G", ref, "-N", tumorName, "-b", tumorBam))
+    buffer.append(VarDictJava.VarDictJava)
+    buffer.append("-N", tumorName)
+    buffer.append("-b", maybeJoinTumorNormalPaths(tumorBam, normalBam))
+    buffer.append("-G", ref)
     if (pileupMode) buffer.append("-p")
-    buffer.append("-z", "1") // Set to 1 since we are using a BED as input
-    buffer.append("-c", "1") // The column for the chromosome
-    buffer.append("-S", "2") // The column for the region start
-    buffer.append("-E", "3") // The column for the region end
-    buffer.append("-g", "4") // The column for the gene name
-    if (!includeNonPf) buffer.append("-F", "0x700") // ignore non-PF reads
-    buffer.append("-f", minimumAf) // The minimum allele frequency threshold
-    minimumAltReads.foreach(buffer.append("-r", _)) // Minimum # of reads supporting an alternate allele
-    minimumQuality.foreach(buffer.append("-q", _)) // The minimum base quality for a "good call"
+    buffer.append("-z", "1") // Set to 1 since we are using a BED as input.
+    buffer.append("-c", "1") // The column for the chromosome.
+    buffer.append("-S", "2") // The column for the region start.
+    buffer.append("-E", "3") // The column for the region end.
+    buffer.append("-g", "4") // The column for the gene name.
+    if (!includeNonPf) buffer.append("-F", "0x700") // Ignore non-PF reads.
+    buffer.append("-f", minimumAf) // The minimum allele frequency threshold.
+    minimumAltReads.foreach(buffer.append("-r", _)) // Minimum # of reads supporting an alternate allele.
+    minimumQuality.foreach(buffer.append("-q", _)) // The minimum base quality for a "good call".
     maximumMismatches.foreach(buffer.append("-m", _)) // Maximum number of mismatches for reads to be included, otherwise they will be filtered.
-    if (countNsInTotalDepth) buffer.append("-K") // count Ns in the total depth ("DP" field)
+    if (countNsInTotalDepth) buffer.append("-K") // Count Ns in the total depth ("DP" field).
     buffer.append("-th", resources.cores.toInt) // The number of threads.
     buffer.append(bed)
 
@@ -118,7 +152,59 @@ private class VarDictJava(tumorBam: PathToBam,
   }
 }
 
-/** Converts VarDictJava tabular output to valid VCF output. */
+/** Converts tumour/normal VarDictJava tabular output to valid VCF output. */
+private class Var2VcfPaired(tumorName: String,
+                            normalName: String,
+                            prefixContigsWithChr: Boolean = true,
+                            includeNonPfVariants: Boolean = false,
+                            outputOnlyCandidateSomatic: Boolean = false,
+                            allVariants: Boolean = true,
+                            maximumDistanceToRemoveHighQualitySnvPairs: Option[Int] = None,
+                            maximumNonMonomerMsi: Option[Int] = None,
+                            maximumMeanMismatches: Option[Double] = None,
+                            maximumPValue: Option[Double] = None,
+                            minimumMeanVariantPositionInReads: Option[Double] = None,
+                            minimumMeanBaseQuality: Option[Double] = None,
+                            minimumMappingQuality: Option[Double] = None,
+                            minimumDepth: Option[Int] = None,
+                            minimumHighQualityAltDepth: Option[Int] = None,
+                            minimumAf: Double = VarDictJava.MinimumAf,
+                            minimumSignalToNoiseRatio: Option[Double] = None,
+                            minimumHomozygousAlleleFreq: Option[Double] = None
+                           ) extends ProcessTask with PipeWithNoResources[Text, Vcf] {
+  name = "Var2VcfPaired"
+
+  /** Format the two sample names into one argument by joining on the default separator. */
+  private def sampleNames: String = {
+    Seq(tumorName, normalName).mkString(VarDictJava.TumorNormalSeparator)
+  }
+
+  override def args: Seq[Any] = {
+    val buffer = new ListBuffer[Any]()
+    buffer.append(VarDictJava.Var2VcfPaired)
+    buffer.append("-N", sampleNames)
+    if (!prefixContigsWithChr) buffer.append("-C")
+    if (!includeNonPfVariants) buffer.append("-S") // If set, variants that did not pass filters will not be present.
+    if (outputOnlyCandidateSomatic) buffer.append("-M") // If set,  output only candidate somatic variant calls.
+    if (allVariants) buffer.append("-A") // Output all variants at the same position, default outputs only the highest AF variant.
+    maximumDistanceToRemoveHighQualitySnvPairs.foreach(buffer.append("-c", _)) // If two seemingly high quality SNV variants are within {int}bp, they're both filtered.
+    maximumNonMonomerMsi.foreach(buffer.append("-I", _)) // The maximum non-monomer MSI allowed for a HT variant with AF < 0.5.
+    maximumMeanMismatches.foreach(buffer.append("-m", _)) // Maximum mean mismatches per read allowed, does not include indels.
+    maximumPValue.foreach(buffer.append("-P", _)) // The maximum p-value.
+    minimumMeanVariantPositionInReads.foreach(buffer.append("-p", _)) // The minimum mean position of variants in the read.
+    minimumMeanBaseQuality.foreach(buffer.append("-q", _)) // The minimum mean base quality.
+    minimumMappingQuality.foreach(buffer.append("-Q", _)) // The minimum mapping quality.
+    minimumDepth.foreach(buffer.append("-d", _)) // The minimum total read depth.
+    minimumHighQualityAltDepth.foreach(buffer.append("-v", _)) // The minimum high quality variant depth.
+    buffer.append("-f", minimumAf) // The minimum allele frequency.
+    minimumSignalToNoiseRatio.foreach(buffer.append("-o", _)) // The minimum signal to noise, or the ratio of hi/(lo+0.5).
+    minimumHomozygousAlleleFreq.foreach(buffer.append("-F", _)) // The minimum allele frequency to consider a variant as homozygous.
+
+    buffer
+  }
+}
+
+/** Converts tumour-only VarDictJava tabular output to valid VCF output. */
 private class Var2VcfValid(sampleName: String,
                            includeNonPfVariants: Boolean = false,
                            allVariants: Boolean = true,
@@ -130,17 +216,18 @@ private class Var2VcfValid(sampleName: String,
                            minimumMappingQuality: Option[Double] = None,
                            minimumDepth: Option[Int] = None,
                            minimumHighQualityAltDepth: Option[Int] = None,
-                           minimumAf: Double = 0.01,
+                           minimumAf: Double = VarDictJava.MinimumAf,
                            minimumSignalToNoiseRatio: Option[Double] = None,
                            minimumHomozygousAlleleFreq: Option[Double] = None,
                            printEndTag: Boolean = false,
                            minimumSplitReadsForSv: Option[Int] = None
-                          ) extends ProcessTask with PipeWithNoResources[Any, Any] {
+                          ) extends ProcessTask with PipeWithNoResources[Text, Vcf] {
   name = "Var2VcfValid"
 
   override def args: Seq[Any] = {
     val buffer = new ListBuffer[Any]()
-    buffer.appendAll(List(VarDictJava.Var2VcfValid, "-N", sampleName))
+    buffer.append(VarDictJava.Var2VcfValid)
+    buffer.append("-N", sampleName)
     if (!includeNonPfVariants) buffer.append("-S") // If set, variants that did not pass filters will not be present.
     if (allVariants) buffer.append("-A") // Output all variants at the same position, default outputs only the highest AF variant.
     maximumDistanceToRemoveHighQualitySnvPairs.foreach(buffer.append("-c", _)) // If two seemingly high quality SNV variants are within {int}bp, they're both filtered.
@@ -161,25 +248,58 @@ private class Var2VcfValid(sampleName: String,
   }
 }
 
-/** Pipeline to call variants from a tumor-only sample using VarDictJava. */
+/** Pipeline to call variants using VarDictJava, supporting tumor-only and tumor-normal mode. */
 @clp(
   description =
     """
-      |Calls somatic variants in a tumor-only sample using VarDictJava.
+      |Call variants using `VarDictJava` in tumor-only or tumor-normal mode.
       |
-      |Tumor-only single-sample variant calling with VarDictJava: https://github.com/AstraZeneca-NGS/VarDictJava
+      |`VarDictJava` is a variant discovery program written in Java. It is a sensitive variant caller for both single
+      |and paired sample variant calling from BAM files. VarDictJava implements several novel features such as amplicon
+      |bias aware variant calling from targeted sequencing experiments, rescue of long indels by realigning bwa
+      |soft-clipped reads, and better scalability than many other Java-based variant callers.
       |
-      |The output Tumor name will be inferred from the the first read group in the input BAM if not provided.
+      |`VarDictJava` performance scales linearly to sequencing depth, making it suitable for high coverage calling.
+      |
+      |## The `VarDictJava` Workflow:
+      |
+      |1. Subset variant calling to the regions of interest provided in `bed`.
+      |2. For each segment in the interval file:
+      |    1. Find all variants:
+      |        - Skip non-passing filter reads.
+      |        - Skip unmapped reads.
+      |        - Skip a read if it does not overlap with the segment.
+      |        - Pre-process the CIGAR string (see https://github.com/AstraZeneca-NGS/VarDictJava#cigar-preprocessing-initial-realignment)
+      |        - For each non-matching position in the alignment, support an existing variant, or create a new variant.
+      |    2. Find structural variants.
+      |    3. Realign some of the variants using information about previously detected structural variation.
+      |    4. Calculate statistics for each variant.
+      |    5. Assign a type to each variant.
+      |    6. Output variants into an intermediate tabular format (`.var`) (see https://github.com/AstraZeneca-NGS/VarDictJava#output-columns)
+      |3. Perform a statistical test:
+      |    - For tumor-only calling, strand bias is tested.
+      |    - For tumor-normal calling, somatic candidacy is tested.
+      |4. Transform the intermediate tabular format to valid VCF output.
+      |
+      |## Sample Names
+      |
+      |The output sample names will be inferred from the first read group in the corresponding input BAM if not provided.
+      |
+      |See the `VarDictJava` documentation for more information:
+      |
+      |  - https://github.com/AstraZeneca-NGS/VarDictJava
     """",
   group = classOf[Pipelines]
 )
 class VarDictJavaEndToEnd
 (@arg(flag='i', doc="The input tumor BAM file.") tumorBam: PathToBam,
+ @arg(flag='I', doc="The input normal BAM file") normalBam: Option[PathToBam] = None,
  @arg(flag='l', doc="The intervals over which to call variants.") bed: FilePath,
- @arg(flag='r', doc="Path to the reference fasta file.") ref: PathToFasta,
+ @arg(flag='r', doc="Path to the reference FASTA file.") ref: PathToFasta,
  @arg(flag='o', doc="The output VCF.") out: PathToVcf,
- @arg(flag='n', doc="The tumor sample name, otherwise taken from the first read group in the BAM.") tumorName: Option[String] = None,
- @arg(flag='f', doc="The minimum allele frequency.") minimumAf: Double = 0.01,
+ @arg(flag='n', doc="The tumor sample name, otherwise taken from the first read group in the tumor BAM.") tumorName: Option[String] = None,
+ @arg(flag='B', doc="The normal sample name, otherwise taken from the first read group in the normal BAM.") normalName: Option[String] = None,
+ @arg(flag='f', doc="The minimum allele frequency.") minimumAf: Double = VarDictJava.MinimumAf,
  @arg(flag='p', doc="Include non-pf reads.") includeNonPf: Boolean = false,
  @arg(flag='S', doc="Include non-pf calls.") includeNonPfVariants: Boolean = true,
  @arg(flag='m', doc="The minimum base quality for a read to support a call.") minimumQuality: Option[Int] = None,
@@ -191,27 +311,33 @@ class VarDictJavaEndToEnd
  @arg(flag='d', doc="The minimum total read depth for a call.") minimumDepth: Option[Int] = None,
  @arg(flag='v', doc="The minimum # of high quality alternate alleles for a call.") minimumHighQualityAltDepth: Option[Int] = None,
  @arg(flag='P', doc="Use the pileup mode (emit all sites with an alternate).") pileupMode: Boolean = false,
- @arg(flag='t', doc="The minimum # of threads with which to run.") minThreads: Int = 1,
- @arg(flag='T', doc="The maximum # of threads with which to run.") maxThreads: Int = 32,
+ @arg(flag='t', doc="The minimum # of threads with which to run.") minThreads: Int = VarDictJava.MinimumThreads,
+ @arg(flag='T', doc="The maximum # of threads with which to run.") maxThreads: Int = VarDictJava.MaximumThreads,
  @arg(flag='a', doc="Output all sites, including reference calls.") allSites: Boolean = false,
  @arg(flag='A', doc="Output all variants at the same genomic site.") allVariants: Boolean = false,
  @arg(flag='N', doc="Count No-calls (Ns) in the total depth tag (DP)") countNsInTotalDepth: Boolean = false) extends Pipeline {
 
-  if (allSites) require(pileupMode, "pileup-mode is required when all-sites is used")
+  if (allSites) require(pileupMode, "pileup-mode is required when all-sites is used.")
+  require(!(normalBam.isEmpty && normalName.nonEmpty), "Normal name cannot be given without a normal BAM file.")
+
+  private val dict = PathUtil.replaceExtension(ref, ".dict")
 
   def build(): Unit = {
-    val tn = tumorName.getOrElse(VarDictJava.extractSampleName(bam = tumorBam))
-    val dict = PathUtil.replaceExtension(ref, ".dict")
+    Io.assertReadable(Seq(tumorBam, ref, dict))
+    Io.assertCanWriteFile(out)
+    normalBam.foreach(Io.assertReadable)
+
+    val tName = tumorName.getOrElse(VarDictJava.extractSampleName(bam = tumorBam))
 
     def f(ext: String): Path = Io.makeTempFile("vardict.", ext, dir = if (out == Io.StdOut) None else Some(out.getParent))
-
     val tmpVcf = f(".vcf")
 
     val vardict = new VarDictJava(
       tumorBam            = tumorBam,
+      normalBam           = normalBam,
       bed                 = bed,
       ref                 = ref,
-      tumorName           = tn,
+      tumorName           = tName,
       minimumAf           = minimumAf,
       includeNonPf        = includeNonPf,
       minimumQuality      = minimumQuality,
@@ -223,24 +349,44 @@ class VarDictJavaEndToEnd
       maxThreads          = maxThreads
     )
 
-    val removeRefEqAltRows = if (allSites) Pipes.empty[Any] else new ShellCommand("awk", "{if ($6 != $7) print}") with PipeWithNoResources[Any, Any]
-    val bias = new ShellCommand(VarDictJava.TestStrandBias.toString) with PipeWithNoResources[Any, Any]
+    val removeRefEqAltRows = if (allSites) Pipes.empty[Text] else new ShellCommand("awk", "{if ($6 != $7) print}") with PipeWithNoResources[Text, Text]
 
-    val var2vcfvalid = new Var2VcfValid(
-      sampleName                        = tn,
-      includeNonPfVariants              = includeNonPfVariants,
-      allVariants                       = allVariants,
-      maximumMeanMismatches             = maximumMeanMismatches,
-      minimumMeanVariantPositionInReads = minimumMeanVariantPositionInReads,
-      minimumMeanBaseQuality            = minimumMeanBaseQuality,
-      minimumDepth                      = minimumDepth,
-      minimumHighQualityAltDepth        = minimumHighQualityAltDepth,
-      minimumAf                         = minimumAf,
-      printEndTag                       = false
-    )
+    val testAndStreamToVcf = normalBam match {
+      case None =>
+        val somatic = new ShellCommand(VarDictJava.TestSomatic.toString) with PipeWithNoResources[Text, Text]
+        val toVcf   = new Var2VcfValid(
+          sampleName                        = tName,
+          includeNonPfVariants              = includeNonPfVariants,
+          allVariants                       = allVariants,
+          maximumMeanMismatches             = maximumMeanMismatches,
+          minimumMeanVariantPositionInReads = minimumMeanVariantPositionInReads,
+          minimumMeanBaseQuality            = minimumMeanBaseQuality,
+          minimumDepth                      = minimumDepth,
+          minimumHighQualityAltDepth        = minimumHighQualityAltDepth,
+          minimumAf                         = minimumAf,
+          printEndTag                       = false
+        )
+        (somatic | toVcf)
+      case Some(_normalBam) =>
+        val nName = normalName.getOrElse(VarDictJava.extractSampleName(bam = _normalBam))
+        val bias  = new ShellCommand(VarDictJava.TestStrandBias.toString) with PipeWithNoResources[Text, Text]
+        val toVcf = new Var2VcfPaired(
+          tumorName                         = tName,
+          normalName                        = nName,
+          includeNonPfVariants              = includeNonPfVariants,
+          allVariants                       = allVariants,
+          maximumMeanMismatches             = maximumMeanMismatches,
+          minimumMeanVariantPositionInReads = minimumMeanVariantPositionInReads,
+          minimumMeanBaseQuality            = minimumMeanBaseQuality,
+          minimumDepth                      = minimumDepth,
+          minimumHighQualityAltDepth        = minimumHighQualityAltDepth,
+          minimumAf                         = minimumAf
+        )
+        (bias | toVcf)
+    }
 
     val sortVcf = new SortVcf(in = tmpVcf, out = out, dict = Some(dict))
 
-    root ==> (vardict | removeRefEqAltRows | bias | var2vcfvalid > tmpVcf).withName("VarDictJavaPipeChain") ==> sortVcf ==> new DeleteFiles(tmpVcf)
+    root ==> (vardict | removeRefEqAltRows | testAndStreamToVcf > tmpVcf).withName("VarDictJavaPipeChain") ==> sortVcf ==> new DeleteFiles(tmpVcf)
   }
 }

--- a/tasks/src/main/scala/dagr/tasks/vc/VarDictJava.scala
+++ b/tasks/src/main/scala/dagr/tasks/vc/VarDictJava.scala
@@ -353,8 +353,8 @@ class VarDictJavaEndToEnd
 
     val testAndStreamToVcf = normalBam match {
       case None =>
-        val somatic = new ShellCommand(VarDictJava.TestSomatic.toString) with PipeWithNoResources[Text, Text]
-        val toVcf   = new Var2VcfValid(
+        val bias         = new ShellCommand(VarDictJava.TestStrandBias.toString) with PipeWithNoResources[Text, Text]
+        val var2VcfValid = new Var2VcfValid(
           sampleName                        = tName,
           includeNonPfVariants              = includeNonPfVariants,
           allVariants                       = allVariants,
@@ -366,11 +366,11 @@ class VarDictJavaEndToEnd
           minimumAf                         = minimumAf,
           printEndTag                       = false
         )
-        (somatic | toVcf)
+        (bias | var2VcfValid)
       case Some(_normalBam) =>
-        val nName = normalName.getOrElse(VarDictJava.extractSampleName(bam = _normalBam))
-        val bias  = new ShellCommand(VarDictJava.TestStrandBias.toString) with PipeWithNoResources[Text, Text]
-        val toVcf = new Var2VcfPaired(
+        val nName         = normalName.getOrElse(VarDictJava.extractSampleName(bam = _normalBam))
+        val somatic       = new ShellCommand(VarDictJava.TestSomatic.toString) with PipeWithNoResources[Text, Text]
+        val var2VcfPaired = new Var2VcfPaired(
           tumorName                         = tName,
           normalName                        = nName,
           includeNonPfVariants              = includeNonPfVariants,
@@ -382,7 +382,7 @@ class VarDictJavaEndToEnd
           minimumHighQualityAltDepth        = minimumHighQualityAltDepth,
           minimumAf                         = minimumAf
         )
-        (bias | toVcf)
+        (somatic | var2VcfPaired)
     }
 
     val sortVcf = new SortVcf(in = tmpVcf, out = out, dict = Some(dict))

--- a/tasks/src/main/scala/dagr/tasks/vc/VarDictJava.scala
+++ b/tasks/src/main/scala/dagr/tasks/vc/VarDictJava.scala
@@ -126,8 +126,8 @@ private class VarDictJava(tumorBam: PathToBam,
   /** Format tumor/normal BAM paths into one argument by joining on the default separator. Defaults to the tumor BAM path. */
   private def maybeJoinTumorNormalPaths(tumorBam: PathToBam, normalBam: Option[PathToBam]): String = {
     VarDictJava.validateSeparatorNotIn(tumorBam.toString, name = "Tumor BAM")
-
     normalBam.foreach(bam => VarDictJava.validateSeparatorNotIn(bam.toString, name = "Normal BAM"))
+
     normalBam match {
       case None             => tumorBam.toString
       case Some(_normalBam) => Seq(tumorBam, _normalBam).mkString(VarDictJava.TumorNormalSeparator)

--- a/tasks/src/main/scala/dagr/tasks/vc/VarDictJava.scala
+++ b/tasks/src/main/scala/dagr/tasks/vc/VarDictJava.scala
@@ -95,7 +95,7 @@ object VarDictJava extends Configuration {
     yieldAndThen(in.getFileHeader.getReadGroups.iterator().next().getSample) { in.close() }
   }
 
-  /** Validate that a string does not contain the `VarDictJava` tumor-normal separator character. */
+  /** Validate that a string does not contain the `VarDictJava` tumor-normal separator. */
   private[vc] def validateSeparatorNotIn(s: String, name: String, sep: String = TumorNormalSeparator): Unit = {
     require(!s.contains(sep), s"$name must not contain '$sep': $s")
   }
@@ -118,7 +118,6 @@ private class VarDictJava(tumorBam: PathToBam,
                           maxThreads: Int = VarDictJava.MaximumThreads,
                           memory: Memory = VarDictJava.DefaultMemory
                          ) extends ProcessTask with VariableResources with PipeOut[Text] {
-  name = "VarDictJava"
 
   override def pickResources(resources: ResourceSet): Option[ResourceSet] = {
     resources.subset(minCores = Cores(minThreads), maxCores = Cores(maxThreads), memory = memory)
@@ -180,7 +179,6 @@ private class Var2VcfPaired(tumorName: String,
                             minimumSignalToNoiseRatio: Option[Double] = None,
                             minimumHomozygousAlleleFreq: Option[Double] = None
                            ) extends ProcessTask with PipeWithNoResources[Text, Vcf] {
-  name = "Var2VcfPaired"
 
   /** Format the two sample names into one argument by joining on the default separator. */
   private def sampleNames: String = {
@@ -233,7 +231,6 @@ private class Var2VcfValid(sampleName: String,
                            printEndTag: Boolean = false,
                            minimumSplitReadsForSv: Option[Int] = None
                           ) extends ProcessTask with PipeWithNoResources[Text, Vcf] {
-  name = "Var2VcfValid"
 
   override def args: Seq[Any] = {
     val buffer = new ListBuffer[Any]()


### PR DESCRIPTION
No regressions or API change.

- [x] Add tumor-normal code paths (`test_somatic.R` and `var2vcf_paired.pl`)
- [x] Type all Pipes (`Text`/`Vcf`)
- [x] Added documentation (too much?)
- [x] Pulled out hard-coded values into defaults.
- [x] Ensure it works!