### PR TITLE
Add Picard VcfFormatConverter task

### DIFF
--- a/tasks/src/main/scala/dagr/tasks/picard/VcfFormatConverter.scala
+++ b/tasks/src/main/scala/dagr/tasks/picard/VcfFormatConverter.scala
@@ -27,11 +27,11 @@ import dagr.tasks.DagrDef.PathToVcf
 
 import scala.collection.mutable.ListBuffer
 
-class VcfFormatConverter(val in: PathToVcf, val out: PathToVcf, val requireIndex: Boolean = true) extends PicardTask {
+class VcfFormatConverter(val in: PathToVcf, val out: PathToVcf) extends PicardTask {
 
   override protected def addPicardArgs(buffer: ListBuffer[Any]): Unit = {
     buffer.append("I=" + in) // The BCF or VCF input file.
     buffer.append("O=" + out) // The BCF or VCF output file name.
-    buffer.append("REQUIRE_INDEX=" + requireIndex) // Fail if an index is not available for the input VCF/BCF.
+    buffer.append("REQUIRE_INDEX=false") // Fail if an index is not available for the input VCF/BCF.
   }
 }

--- a/tasks/src/main/scala/dagr/tasks/picard/VcfFormatConverter.scala
+++ b/tasks/src/main/scala/dagr/tasks/picard/VcfFormatConverter.scala
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2015 Fulcrum Genomics LLC
+ * Copyright (c) 2018 Fulcrum Genomics LLC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,8 +27,7 @@ import dagr.tasks.DagrDef.PathToVcf
 
 import scala.collection.mutable.ListBuffer
 
-class VcfFormatConverter(val in: PathToVcf, val out: PathToVcf, val requireIndex: Boolean = true)
-  extends PicardTask {
+class VcfFormatConverter(val in: PathToVcf, val out: PathToVcf, val requireIndex: Boolean = true) extends PicardTask {
 
   override protected def addPicardArgs(buffer: ListBuffer[Any]): Unit = {
     buffer.append("I=" + in) // The BCF or VCF input file.

--- a/tasks/src/main/scala/dagr/tasks/picard/VcfFormatConverter.scala
+++ b/tasks/src/main/scala/dagr/tasks/picard/VcfFormatConverter.scala
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2018 Fulcrum Genomics LLC
+ * Copyright (c) 2019 Fulcrum Genomics LLC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/tasks/src/main/scala/dagr/tasks/picard/VcfFormatConverter.scala
+++ b/tasks/src/main/scala/dagr/tasks/picard/VcfFormatConverter.scala
@@ -1,0 +1,38 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package dagr.tasks.picard
+
+import dagr.tasks.DagrDef.PathToVcf
+
+import scala.collection.mutable.ListBuffer
+
+class VcfFormatConverter(val in: PathToVcf, val out: PathToVcf, val requireIndex: Boolean = true)
+  extends PicardTask {
+
+  override protected def addPicardArgs(buffer: ListBuffer[Any]): Unit = {
+    buffer.append("I=" + in) // The BCF or VCF input file.
+    buffer.append("O=" + out) // The BCF or VCF output file name.
+    buffer.append("REQUIRE_INDEX=" + requireIndex) // Fail if an index is not available for the input VCF/BCF.
+  }
+}


### PR DESCRIPTION
- [x] All CLI options available in Task
- [x] I confirm works on plain `.vcf` output and compressed `.vcf.gz`/`.vcf.bgz`