### PR TITLE
Allow building a Core resource from String

### DIFF
--- a/core/src/main/scala/dagr/core/execsystem/Resource.scala
+++ b/core/src/main/scala/dagr/core/execsystem/Resource.scala
@@ -157,9 +157,10 @@ case class Cores(override val value: Double) extends Resource[Double, Cores](val
   override protected def build(value: Double): Cores = new Cores(value)
 }
 
-/** Companion object for Core adding an additional apply() method. */
+/** Companion object for Core with additional apply() methods. */
 object Cores {
-  def apply(cores: Cores): Cores = new Cores(cores.value)
+  def apply(cores: Cores): Cores  = new Cores(cores.value)
+  def apply(cores: String): Cores = new Cores(cores.toDouble)
   val none = Cores(0.0)
   val infinite = Cores(Double.MaxValue) // Not really infinite, but close to it.
 }

--- a/core/src/test/scala/dagr/core/execsystem/ResourceTest.scala
+++ b/core/src/test/scala/dagr/core/execsystem/ResourceTest.scala
@@ -123,6 +123,13 @@ class ResourceTest extends UnitSpec {
     Memory("1G").toString shouldBe (1024*1024*1024).toString
   }
 
+  "Cores" should "allow building from other types" in {
+    Cores(Cores(1)) shouldBe Cores(1)
+    Cores("1") shouldBe Cores(1)
+    Cores(Cores(1.0)) shouldBe Cores(1.0)
+    Cores("1.0") shouldBe Cores(1.0)
+  }
+
   "Memory" should "represent its value in pretty formats" in {
     var mem = Memory(1024.toLong * 1024.toLong * 1024.toLong * 2.toLong)
     mem.kb shouldBe "2097152k"


### PR DESCRIPTION
I have a pipeline where I would like to parameterize the compute resources for one of the tasks using the CLI like this toy example:

```scala
@clp(description = "Demo!", group = classOf[Pipelines])
class ExamplePipeline(
  @arg(doc="The cores for task 1") val cores: Cores = Cores(6.0),
  @arg(doc="The memory for task 1") val memory: Memory = "2G"
) extends Pipeline {

  override def build(): Unit = {
    task1 = new ShellCommand("echo", "task1").requires(cores, memory)
    task2 = new ShellCommand("echo", "task2")
    root ==> (task1 :: task2)
  }
}
```

At runtime I get:

```
...
--cores=Cores                 The cores for task 1. [Default: 6.0].
--memory=Memory               The memory for task 1. [Default: 2G].

Argument 'cores' could not be constructed from string
	...Could not build a 'Cores' from a string: 6: dagr.core.execsystem.Cores$.apply(java.lang.String)
java.lang.Class.getMethod(Class.java:1786)
com.fulcrumgenomics.commons.reflect.ReflectionUtil$$anonfun$$nestedInanonfun$buildUnitFromString$1$1.$anonfun$applyOrElse$1(ReflectionUtil.scala:407)
scala.util.Try$.apply(Try.scala:209)
com.fulcrumgenomics.commons.reflect.ReflectionUtil$$anonfun$$nestedInanonfun$buildUnitFromString$1$1.applyOrElse(ReflectionUtil.scala:401)
com.fulcrumgenomics.commons.reflect.ReflectionUtil$$anonfun$$nestedInanonfun$buildUnitFromString$1$1.applyOrElse(ReflectionUtil.scala:399)
scala.runtime.AbstractPartialFunction.apply(AbstractPartialFunction.scala:34)
scala.util.Failure.recover(Try.scala:230)
...
```

Would you be willing to allow for building `Core` resources from Strings?

EDIT: Fixed type of cores in toy example.