### PR TITLE
Optionally check configureExecutable config value path actually exists

### DIFF
--- a/core/src/main/scala/dagr/core/config/Configuration.scala
+++ b/core/src/main/scala/dagr/core/config/Configuration.scala
@@ -166,9 +166,9 @@ private[config] trait ConfigurationLike extends LazyLogging {
   }
 
   /**
-    * Attempts to determine the path to an executable, first by looking it up in config and optionally checking to see
-    * if the path exists. If that fails, we will then locate the executable on the system path. If both strategies fail,
-    * then an exception is raised.
+    * Attempts to determine the path to an executable, first by looking it up in the config and optionally checking to
+    * see if the path exists. If that fails, we will then locate the executable on the system path. If both strategies
+    * fail, then an exception is raised.
     *
     * @param path the configuration path to look up
     * @param executable the default name of the executable
@@ -182,11 +182,12 @@ private[config] trait ConfigurationLike extends LazyLogging {
     optionallyConfigure[Path](path)
       .filterNot(mustExist && !Files.exists(_))
       .orElse(findInPath(executable))
+      .map(_.toAbsolutePath)
       .getOrElse(
         throw new Generic(
-          s"Could not configurable executable. "
-          + s"Config path '$path' is not defined, or the config value references a file which does not exist, "
-          + s"and executable '$executable' is not in PATH."
+          s"Could not configure executable."
+          + s" Config path '$path' is not defined, or the config value references a file which does not exist,"
+          + s" and executable '$executable' is not in the system path."
         )
       )
   }

--- a/core/src/test/scala/dagr/core/config/ConfigurationTest.scala
+++ b/core/src/test/scala/dagr/core/config/ConfigurationTest.scala
@@ -143,7 +143,7 @@ class ConfigurationTest extends UnitSpec with CaptureSystemStreams {
     Files.isExecutable(java) shouldBe true
 
     // If the config key is found, but the value, as a path, does not exist, then fallback to the system path.
-    java = conf.configureExecutable("some-executable", "java", mustExist = true)
+    java = conf.configureExecutable("some-executable", "java", allowMissingConfigReference = false)
     java.getFileName.toString shouldBe "java"
     Files.isExecutable(java) shouldBe true
 

--- a/core/src/test/scala/dagr/core/config/ConfigurationTest.scala
+++ b/core/src/test/scala/dagr/core/config/ConfigurationTest.scala
@@ -142,6 +142,11 @@ class ConfigurationTest extends UnitSpec with CaptureSystemStreams {
     java.getFileName.toString shouldBe "java"
     Files.isExecutable(java) shouldBe true
 
+    // If the config key is found, but the value, as a path, does not exist, then fallback to the system path.
+    java = conf.configureExecutable("some-executable", "java", mustExist = true)
+    java.getFileName.toString shouldBe "java"
+    Files.isExecutable(java) shouldBe true
+
     // the bin directory should not be found, and so should fall back on the system path, and find the java executable
     java = conf.configureExecutableFromBinDirectory("path-does-not-exist", "java")
     java.getFileName.toString shouldBe "java"


### PR DESCRIPTION
I have a use case which is not supported by Dagr's current methods for executable configuration.

I want to configure a default location where executables can be placed such that Dagr always uses them if they can be found. If the executables do not exist on disk at the path specified in configuration, then I want Dagr to fallback onto the system path.

With this PR, two alternate behaviors can be allowed without changing Dagr configuration. This will make sharing Dagr pipelines easier!

#### Dependency Strategies I want to Advertise

1. To get up and running very quickly, install dependencies with this command:

    ```bash
    ❯ conda install vcfanno
    ```

	Then execute the pipeline:

    ```bash
    ❯ java -jar pipeline.jar RunMe
    ```

2. To use a specific version of the pipeline dependencies or to use a different version than provided on your system path, simply place the executables at the following location:

    ```bash
    ❯ ls /pipeline/packages/
	/pipeline/packages/vcfanno 
    ```

	Then execute the pipeline:

    ```bash
    ❯ java -jar pipeline.jar RunMe
    ```

---

I'm not thrilled about providing the argument `mustExist`, would you rather this logic be allowed through a new function? Open to suggestions!