### PR TITLE
Implement helper method PicardTask.withValidationStringency()

### DIFF
--- a/tasks/src/main/scala/dagr/tasks/picard/PicardTask.scala
+++ b/tasks/src/main/scala/dagr/tasks/picard/PicardTask.scala
@@ -108,4 +108,9 @@ abstract class PicardTask(var jvmArgs: List[String] = Nil,
   /** Sets asynchronous IO on or off. */
   def withIndexing(indexing: Boolean = true) : this.type = { this.createIndex = Some(indexing); this; }
 
+  /** Sets the validation stringency to a specific level. */
+  def withValidationStringency(validationStringency: ValidationStringency) : this.type = {
+    this.validationStringency = Some(validationStringency)
+    this
+  }
 }


### PR DESCRIPTION
I would like to do:

```scala
val laneMetrics = new CollectIlluminaLaneMetrics(
  runDirectory    = runDirectory,
  output          = output,
  flowcellBarcode = flowcellBarcode,
  readStructure   = readStructure
) withValidationStringency ValidationStringency.LENIENT
```

Instead of:

```scala
val laneMetrics = new CollectIlluminaLaneMetrics(
  runDirectory    = runDirectory,
  output          = output,
  flowcellBarcode = flowcellBarcode,
  readStructure   = readStructure
)
laneMetrics.validationStringency = Some(ValidationStringency.LENIENT)
```