### PR TITLE
Move cross-building to 2.12 and 2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: required
+dist: trusty
 language: scala
 scala:
 - 2.12.2

--- a/build.sbt
+++ b/build.sbt
@@ -88,9 +88,9 @@ lazy val commonSettings = Seq(
   organizationHomepage := Some(url("http://www.fulcrumgenomics.com")),
   homepage             := Some(url("http://github.com/fulcrumgenomics/dagr")),
   startYear            := Some(2015),
-  scalaVersion         := "2.12.6",
-  crossScalaVersions   := Seq("2.12.6", "2.11.12"),
-  scalacOptions        += "-target:jvm-1.8",
+  scalaVersion         := "2.13.0",
+  crossScalaVersions   := Seq("2.12.8", "2.13.0"),
+  scalacOptions        ++= Seq("-target:jvm-1.8", "-deprecation"),
   scalacOptions in (Compile, doc) ++= docScalacOptions,
   scalacOptions in (Test, doc) ++= docScalacOptions,
   autoAPIMappings := true,
@@ -111,7 +111,7 @@ lazy val commonSettings = Seq(
   // See https://github.com/sbt/sbt/issues/653
   // and https://github.com/travis-ci/travis-ci/issues/3775
   javaOptions in Test += "-Xmx1G",
-  libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % "test->*" excludeAll ExclusionRule(organization="org.junit", name="junit"),
+  libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.8" % "test->*" excludeAll ExclusionRule(organization="org.junit", name="junit"),
   assemblyJarName in assembly := s"${name.value}-${version.value}.jar"
 ) ++ Defaults.coreDefaultSettings ++ sonatypeSettings
 
@@ -123,14 +123,15 @@ lazy val core = Project(id="dagr-core", base=file("core"))
   .settings(description := "Core methods and classes to execute tasks in dagr.")
   .settings(
     libraryDependencies ++= Seq(
-      "com.fulcrumgenomics" %%  "commons"           %  "0.6.1",
-      "com.fulcrumgenomics" %%  "sopt"              %  "0.6.1",
+      "com.fulcrumgenomics" %%  "commons"           %  "0.8.0-87f4b88-SNAPSHOT",
+      "com.fulcrumgenomics" %%  "sopt"              %  "0.8.0-6330673-SNAPSHOT",
       "com.github.dblock"   %   "oshi-core"         %  "3.3",
       "org.scala-lang"      %   "scala-reflect"     %  scalaVersion.value,
       "org.scala-lang"      %   "scala-compiler"    %  scalaVersion.value,
       "org.reflections"     %   "reflections"       %  "0.9.10",
       "com.typesafe"        %   "config"            %  "1.3.2",
-      "javax.servlet"       %   "javax.servlet-api" %  "3.1.0"
+      "javax.servlet"       %   "javax.servlet-api" %  "3.1.0",
+      "jline"               %   "jline"             %  "2.14.2"
     )
   )
   .disablePlugins(sbtassembly.AssemblyPlugin)

--- a/core/src/main/scala/dagr/core/cmdline/DagrCoreMain.scala
+++ b/core/src/main/scala/dagr/core/cmdline/DagrCoreMain.scala
@@ -222,7 +222,7 @@ class DagrCoreMain extends LazyLogging {
 
     val startTime = System.currentTimeMillis()
     val packages = Sopt.find[Pipeline](packageList, includeHidden=includeHidden)
-    val exit      = Sopt.parseCommandAndSubCommand[DagrCoreArgs,Pipeline](name, args, packages) match {
+    val exit      = Sopt.parseCommandAndSubCommand[DagrCoreArgs,Pipeline](name, args.toIndexedSeq, packages) match {
       case Sopt.Failure(usage) =>
         System.err.print(usage())
         1
@@ -267,7 +267,7 @@ class DagrCoreMain extends LazyLogging {
 
   /** Loads the various dagr scripts and puts them on the classpath. */
   private def loadScripts(args: Array[String]): Unit = {
-    val tokenizer = new ArgTokenizer(args, argFilePrefix=Some("@"))
+    val tokenizer = new ArgTokenizer(args.toIndexedSeq, argFilePrefix=Some("@"))
     val collator = new ArgTokenCollator(tokenizer)
     collator.filter(_.isSuccess).foreach {
       case Success(ArgOptionAndValues(name: String, values: Seq[String])) if name == "scripts" =>

--- a/core/src/main/scala/dagr/core/cmdline/DagrScriptManager.scala
+++ b/core/src/main/scala/dagr/core/cmdline/DagrScriptManager.scala
@@ -31,9 +31,9 @@ import java.nio.file.Path
 
 import com.fulcrumgenomics.commons.io.Io
 import com.fulcrumgenomics.commons.util.{LazyLogging, LogLevel}
+import com.fulcrumgenomics.commons.CommonsDef._
 import org.reflections.util.ClasspathHelper
 
-import scala.collection.JavaConversions._
 import scala.reflect.internal.util.{FakePos, NoPosition, Position, StringOps}
 import scala.tools.nsc.io.PlainFile
 import scala.tools.nsc.reporters.AbstractReporter

--- a/core/src/main/scala/dagr/core/cmdline/DagrScriptManager.scala
+++ b/core/src/main/scala/dagr/core/cmdline/DagrScriptManager.scala
@@ -52,7 +52,7 @@ object DagrScriptManager {
     * HACK: Uses reflection to modify the class path, and assumes loader is a URLClassLoader.
     * @param urls URLs to add to the system class loader classpath.
     */
-  private def addToClasspath(urls: Traversable[URL]): Unit = {
+  private def addToClasspath(urls: Iterable[URL]): Unit = {
     Thread.currentThread().setContextClassLoader(new URLClassLoader(urls.toArray, Thread.currentThread().getContextClassLoader))
   }
 
@@ -156,7 +156,7 @@ private[core] class DagrScriptManager extends LazyLogging {
     * Compiles and loads the scripts in the files into the current classloader.
     * Heavily based on scala/src/compiler/scala/tools/ant/Scalac.scala
     */
-  def loadScripts(scripts: Traversable[Path], tempDir: Path, quiet: Boolean = true): Unit = {
+  def loadScripts(scripts: Iterable[Path], tempDir: Path, quiet: Boolean = true): Unit = {
     // Make sure the scripts actually exist and we can write to the tempDir
     Io.assertReadable(scripts)
     Io.assertWritableDirectory(tempDir)

--- a/core/src/main/scala/dagr/core/config/Configuration.scala
+++ b/core/src/main/scala/dagr/core/config/Configuration.scala
@@ -223,7 +223,7 @@ private[config] trait ConfigurationLike extends LazyLogging {
     * Grabs the config key "PATH" which, if not defined in config will default to the environment variable
     * PATH, splits it on the path separator and returns it as a Seq[String]
     */
-  protected def systemPath : Seq[Path] = config.getString(Configuration.Keys.SystemPath).split(File.pathSeparatorChar).map(pathTo(_))
+  protected def systemPath : Seq[Path] = config.getString(Configuration.Keys.SystemPath).split(File.pathSeparatorChar).toSeq.map(pathTo(_))
 
   /** Removes various characters from the simple class name, for scala class names. */
   private def sanitizeSimpleClassName(className: String): String = {

--- a/core/src/main/scala/dagr/core/execsystem/GraphNode.scala
+++ b/core/src/main/scala/dagr/core/execsystem/GraphNode.scala
@@ -39,7 +39,7 @@ import scala.collection.mutable.ListBuffer
   *                         nodes are [[dagr.core.tasksystem.Pipeline]]s.
   */
 class GraphNode(var task: Task,
-                predecessorNodes: Traversable[GraphNode] = Nil,
+                predecessorNodes: Iterable[GraphNode] = Nil,
                 var state: GraphNodeState.Value = GraphNodeState.PREDECESSORS_AND_UNEXPANDED,
                 val enclosingNode: Option[GraphNode] = None) extends BaseGraphNode {
 
@@ -89,8 +89,8 @@ class GraphNode(var task: Task,
     * @param predecessor the predecessor(s) to add
     * @return true if the predecessor was not already added and added successfully, false otherwise
     */
-  def addPredecessors(predecessor: Traversable[GraphNode]): Boolean = {
-    addPredecessors(predecessor.toArray:_*)
+  def addPredecessors(predecessor: Iterable[GraphNode]): Boolean = {
+    addPredecessors(predecessor.toSeq:_*)
   }
 
   /** Get the predecessors

--- a/core/src/main/scala/dagr/core/execsystem/NaiveScheduler.scala
+++ b/core/src/main/scala/dagr/core/execsystem/NaiveScheduler.scala
@@ -31,7 +31,7 @@ class NaiveScheduler extends Scheduler {
     * Takes the list of tasks that could be scheduled if their resource needs can be met and attempts
     * to schedule a single task for execution.
     */
-  private[execsystem] def scheduleOneTask(readyTasks: Traversable[UnitTask],
+  private[execsystem] def scheduleOneTask(readyTasks: Iterable[UnitTask],
                                           remainingSystemCores: Cores,
                                           remainingSystemMemory: Memory,
                                           remainingJvmMemory: Memory): Option[(UnitTask, ResourceSet)] = {
@@ -64,7 +64,7 @@ class NaiveScheduler extends Scheduler {
     * @param remainingJvmMemory the set of remaining JVM memory, not including running tasks.
     * @return a map of tasks should be scheduled and their allocate resources.
     */
-  private def scheduleOnce(readyTasks: Traversable[UnitTask],
+  private def scheduleOnce(readyTasks: Iterable[UnitTask],
                            remainingSystemCores: Cores,
                            remainingSystemMemory: Memory,
                            remainingJvmMemory: Memory): List[(UnitTask, ResourceSet)] = {
@@ -111,7 +111,7 @@ class NaiveScheduler extends Scheduler {
    * @param jvmMemory the JVM memory available.
    * @return the map of tasks should be scheduled.
    */
-  override def schedule(readyTasks: Traversable[UnitTask],
+  override def schedule(readyTasks: Iterable[UnitTask],
                         systemCores: Cores,
                         systemMemory: Memory,
                         jvmMemory: Memory

--- a/core/src/main/scala/dagr/core/execsystem/ResourceSet.scala
+++ b/core/src/main/scala/dagr/core/execsystem/ResourceSet.scala
@@ -59,10 +59,10 @@ case class ResourceSet(cores: Cores = Cores.none, memory: Memory = Memory.none) 
     * number of cores. Will greedily assign the highest number of cores possible.
     */
   def subset(minCores: Cores, maxCores: Cores, memory: Memory) : Option[ResourceSet] = {
-    val min = math.ceil(minCores.value).toInt
-    val max = math.floor(maxCores.value).toInt
-    val cores = max.to(min, -1).find(cores => subset(Cores(cores), memory).isDefined)
-    cores.map(c => ResourceSet(Cores(c), memory))
+    val min = minCores.value
+    val max = maxCores.value
+    val cores = Range.BigDecimal.inclusive(max, min, -1).find(cores => subset(Cores(cores.doubleValue), memory).isDefined)
+    cores.map(c => ResourceSet(Cores(c.doubleValue), memory))
   }
 
   /**

--- a/core/src/main/scala/dagr/core/execsystem/ResourceSet.scala
+++ b/core/src/main/scala/dagr/core/execsystem/ResourceSet.scala
@@ -59,8 +59,8 @@ case class ResourceSet(cores: Cores = Cores.none, memory: Memory = Memory.none) 
     * number of cores. Will greedily assign the highest number of cores possible.
     */
   def subset(minCores: Cores, maxCores: Cores, memory: Memory) : Option[ResourceSet] = {
-    val min = minCores.value
-    val max = maxCores.value
+    val min = math.ceil(minCores.value).toInt
+    val max = math.floor(maxCores.value).toInt
     val cores = max.to(min, -1).find(cores => subset(Cores(cores), memory).isDefined)
     cores.map(c => ResourceSet(Cores(c), memory))
   }

--- a/core/src/main/scala/dagr/core/execsystem/Scheduler.scala
+++ b/core/src/main/scala/dagr/core/execsystem/Scheduler.scala
@@ -40,7 +40,7 @@ abstract class Scheduler extends LazyLogging {
     * @return a map of tasks should be scheduled and their allocate resources.
     * */
   final def schedule(runningTasks: Map[UnitTask, ResourceSet],
-               readyTasks: Traversable[UnitTask],
+               readyTasks: Iterable[UnitTask],
                systemCores: Cores,
                systemMemory: Memory,
                jvmMemory: Memory): Map[UnitTask, ResourceSet] =  {
@@ -77,7 +77,7 @@ abstract class Scheduler extends LazyLogging {
   /** All schedulers should implement this method.  Returns a map of scheduled tasks to their resources to use
     * while running.
     */
-  protected def schedule(readyTasks: Traversable[UnitTask],
+  protected def schedule(readyTasks: Iterable[UnitTask],
                          systemCores: Cores,
                          systemMemory: Memory,
                          jvmMemory: Memory): Map[UnitTask, ResourceSet]

--- a/core/src/main/scala/dagr/core/execsystem/TaskManager.scala
+++ b/core/src/main/scala/dagr/core/execsystem/TaskManager.scala
@@ -511,7 +511,7 @@ class TaskManager(taskManagerResources: SystemResources = TaskManagerDefaults.de
 
   protected[core] def readyTasksList: List[UnitTask] = graphNodesInStateFor(NO_PREDECESSORS).toList.map(node => node.task.asInstanceOf[UnitTask])
 
-  override def stepExecution(): (Traversable[Task], Traversable[Task], Traversable[Task], Traversable[Task]) = {
+  override def stepExecution(): (Iterable[Task], Iterable[Task], Iterable[Task], Iterable[Task]) = {
     logger.debug("runSchedulerOnce: starting one round of execution")
 
     // get newly completed tasks

--- a/core/src/main/scala/dagr/core/execsystem/TaskManagerLike.scala
+++ b/core/src/main/scala/dagr/core/execsystem/TaskManagerLike.scala
@@ -163,5 +163,5 @@ private[execsystem] trait TaskManagerLike {
     *         (3) tasks that are running prior to scheduling.
     *         (4) the tasks that have completed prior to scheduling.
     */
-  def stepExecution(): (Traversable[Task], Traversable[Task], Traversable[Task], Traversable[Task])
+  def stepExecution(): (Iterable[Task], Iterable[Task], Iterable[Task], Iterable[Task])
 }

--- a/core/src/main/scala/dagr/core/execsystem/TaskTracker.scala
+++ b/core/src/main/scala/dagr/core/execsystem/TaskTracker.scala
@@ -125,7 +125,7 @@ trait TaskTracker extends TaskManagerLike with LazyLogging {
     * @param ignoreExists true if we just return the task id for already added tasks, false if we are to throw an [[IllegalArgumentException]]
     * @return the task identifiers.
     */
-  protected[execsystem] def addTasks(tasks: Traversable[Task], enclosingNode: Option[GraphNode] = None, ignoreExists: Boolean = false): List[TaskId] = {
+  protected[execsystem] def addTasks(tasks: Iterable[Task], enclosingNode: Option[GraphNode] = None, ignoreExists: Boolean = false): List[TaskId] = {
     tasks.map(task => addTask(task=task, enclosingNode=enclosingNode, ignoreExists=ignoreExists)).toList
   }
 
@@ -286,11 +286,11 @@ trait TaskTracker extends TaskManagerLike with LazyLogging {
    * @return the list of precedessors, or Nil if this task has no predecessors.  If there were predecessors that
     *         are not currently being tracked, None will be returned instead.
     */
-  protected def predecessorsOf(task: Task): Option[Traversable[GraphNode]] = {
+  protected def predecessorsOf(task: Task): Option[Iterable[GraphNode]] = {
     task.tasksDependedOn match {
       case Nil => Some(Nil)
       case _ =>
-        val predecessors: Traversable[Option[GraphNode]] = for (dependency <- task.tasksDependedOn) yield graphNodeFor(dependency)
+        val predecessors: Iterable[Option[GraphNode]] = for (dependency <- task.tasksDependedOn) yield graphNodeFor(dependency)
         if (predecessors.exists(_.isEmpty)) None // we found predecessors that have no associated graph node
         else Some(predecessors.map(_.get))
     }
@@ -310,7 +310,7 @@ trait TaskTracker extends TaskManagerLike with LazyLogging {
     * @param states the states of the returned graph nodes.
     * @return the graph nodes with the given states.
     */
-  protected def graphNodesInStatesFor(states: Traversable[GraphNodeState.Value]): Iterable[GraphNode] = {
+  protected def graphNodesInStatesFor(states: Iterable[GraphNodeState.Value]): Iterable[GraphNode] = {
     graphNodes.filter(n => states.toList.contains(n.state))
   }
 

--- a/core/src/main/scala/dagr/core/execsystem/TopLikeStatusReporter.scala
+++ b/core/src/main/scala/dagr/core/execsystem/TopLikeStatusReporter.scala
@@ -33,10 +33,10 @@ import com.fulcrumgenomics.commons.util.TimeUtil._
 import dagr.core.execsystem.GraphNodeState._
 import dagr.core.execsystem.TopLikeStatusReporter.{ReportField, StatusRunnable}
 import dagr.core.tasksystem.{InJvmTask, ProcessTask, Task, UnitTask}
+import jline.{TerminalFactory, Terminal => JLineTerminal}
 
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
-import scala.tools.jline_embedded.{Terminal => JLineTerminal, TerminalFactory}
 
 /** Simple methods for a terminal */
 object Terminal {
@@ -62,13 +62,13 @@ trait Terminal {
   * See: http://www.tldp.org/HOWTO/Bash-Prompt-HOWTO/x361.html
   */
 object CursorMovement {
-  def positionCursor(line: Int, column: Int): String = s"\033[$line;${column}H"
+  def positionCursor(line: Int, column: Int): String = s"\u001b$line;${column}H"
   //def moveUp(numLines: Int): String = s"\033[${numLines}A"
   //def moveDown(numLines: Int): String = s"\033[${numLines}B"
   //def moveRight(numColumns: Int): String = s"\033[${numColumns}C"
   //def moveLeft(numColumns: Int): String = s"\033[${numColumns}D"
-  def clearScreen: String = "\033[2J"
-  def eraseToEOL: String = "\033[K"
+  def clearScreen: String = "\u001b[2J"
+  def eraseToEOL: String = "\u001b[K"
 }
 
 object TopLikeStatusReporter {

--- a/core/src/main/scala/dagr/core/tasksystem/Dependable.scala
+++ b/core/src/main/scala/dagr/core/tasksystem/Dependable.scala
@@ -63,13 +63,13 @@ trait Dependable {
   }
 
   /** Must be implemented to return all tasks on which new predecessor dependencies should be added. */
-  def headTasks: Traversable[Task]
+  def headTasks: Iterable[Task]
 
   /** Must be implemented to return all tasks on which new successor dependencies should be added. */
-  def tailTasks: Traversable[Task]
+  def tailTasks: Iterable[Task]
 
   /** Must be implemented to return all tasks represented by the Dependable. */
-  def allTasks: Traversable[Task]
+  def allTasks: Iterable[Task]
 }
 
 /** An object that can be implicitly converted to from a None when using Option[Dependable]. */
@@ -82,9 +82,9 @@ object EmptyDependable extends Dependable {
 
   override def addDependent(dependent: Dependable): Unit = ()
   override def !=>(other: Dependable): Unit = ()
-  override def headTasks: Traversable[Task] = Nil
-  override def tailTasks: Traversable[Task] = Nil
-  override def allTasks: Traversable[Task]  = Nil
+  override def headTasks: Iterable[Task] = Nil
+  override def tailTasks: Iterable[Task] = Nil
+  override def allTasks: Iterable[Task]  = Nil
 }
 
 /**
@@ -98,9 +98,9 @@ case class DependencyChain(from: Dependable, to: Dependable) extends Dependable 
   override def !=>(other: Dependable): Unit = to !=> other
 
 
-  override def headTasks: Traversable[Task] = from.headTasks
-  override def tailTasks: Traversable[Task] = to.tailTasks
-  override def allTasks: Traversable[Task]  = from.allTasks ++ to.allTasks
+  override def headTasks: Iterable[Task] = from.headTasks
+  override def tailTasks: Iterable[Task] = to.tailTasks
+  override def allTasks: Iterable[Task]  = from.allTasks ++ to.allTasks
 }
 
 /**
@@ -119,7 +119,7 @@ case class DependencyGroup(a: Dependable, b: Dependable) extends Dependable {
     f(b)
   }
 
-  override def headTasks: Traversable[Task] = a.headTasks ++ b.headTasks
-  override def tailTasks: Traversable[Task] = a.tailTasks ++ b.tailTasks
-  override def allTasks: Traversable[Task]  = a.allTasks  ++ b.allTasks
+  override def headTasks: Iterable[Task] = a.headTasks ++ b.headTasks
+  override def tailTasks: Iterable[Task] = a.tailTasks ++ b.tailTasks
+  override def allTasks: Iterable[Task]  = a.allTasks  ++ b.allTasks
 }

--- a/core/src/main/scala/dagr/core/tasksystem/Dependable.scala
+++ b/core/src/main/scala/dagr/core/tasksystem/Dependable.scala
@@ -80,8 +80,8 @@ object EmptyDependable extends Dependable {
     case None    => EmptyDependable
   }
 
-  override def addDependent(dependent: Dependable): Unit = Unit
-  override def !=>(other: Dependable): Unit = Unit
+  override def addDependent(dependent: Dependable): Unit = ()
+  override def !=>(other: Dependable): Unit = ()
   override def headTasks: Traversable[Task] = Nil
   override def tailTasks: Traversable[Task] = Nil
   override def allTasks: Traversable[Task]  = Nil

--- a/core/src/main/scala/dagr/core/tasksystem/EitherTask.scala
+++ b/core/src/main/scala/dagr/core/tasksystem/EitherTask.scala
@@ -60,5 +60,5 @@ object EitherTask {
   */
 class EitherTask private (private val left: Task, private val right: Task, private val choice: () => EitherTask.Choice) extends Task {
   /** Decides which task to return based on `choice` at execution time. */
-  override def getTasks: Traversable[Task] = Seq(if (choice() eq EitherTask.Left) left else right)
+  override def getTasks: Iterable[Task] = Seq(if (choice() eq EitherTask.Left) left else right)
 }

--- a/core/src/main/scala/dagr/core/tasksystem/NoOpInJvmTask.scala
+++ b/core/src/main/scala/dagr/core/tasksystem/NoOpInJvmTask.scala
@@ -28,5 +28,5 @@ package dagr.core.tasksystem
  */
 class NoOpInJvmTask(taskName: String) extends SimpleInJvmTask {
   this.name = taskName
-  override def run(): Unit = Unit
+  override def run(): Unit = ()
 }

--- a/core/src/main/scala/dagr/core/tasksystem/Pipeline.scala
+++ b/core/src/main/scala/dagr/core/tasksystem/Pipeline.scala
@@ -44,9 +44,9 @@ abstract class Pipeline(val outputDirectory: Option[Path] = None,
     /** Breaks the dependency link between this dependable and the provided Task. */
     override def !=> (other: Dependable): Unit = other.headTasks.foreach(tasks.remove)
 
-    override def headTasks: Traversable[Task] = Pipeline.this.headTasks
-    override def tailTasks: Traversable[Task] = Pipeline.this.tailTasks
-    override def allTasks: Traversable[Task]  = Pipeline.this.allTasks
+    override def headTasks: Iterable[Task] = Pipeline.this.headTasks
+    override def tailTasks: Iterable[Task] = Pipeline.this.tailTasks
+    override def allTasks: Iterable[Task]  = Pipeline.this.allTasks
   }
 
   /**
@@ -59,7 +59,7 @@ abstract class Pipeline(val outputDirectory: Option[Path] = None,
     *
     * @return the list of tasks of to run.
     */
-  final override def getTasks: Traversable[_ <: Task] = {
+  final override def getTasks: Iterable[_ <: Task] = {
     build()
     tasks.toList.foreach(addChildren)
 

--- a/core/src/main/scala/dagr/core/tasksystem/Schedulable.scala
+++ b/core/src/main/scala/dagr/core/tasksystem/Schedulable.scala
@@ -95,8 +95,8 @@ trait Schedulable {
   private[tasksystem] def minCores(start: Cores = OneCore, end: Cores = EndCores, step: Cores = OneCore, maxMemory: Memory = EndMemory): Option[Cores] = {
     // first check that the search will succeed, then test a range of values for cores
     this.pickResources(availableResources = new ResourceSet(end, maxMemory)).flatMap { _ =>
-      (start.value to end.value by step.value).flatMap { cores =>
-        val availableResources = new ResourceSet(Cores(cores), maxMemory)
+      Range.BigDecimal.inclusive(start.value, end.value, step.value).flatMap { cores =>
+        val availableResources = new ResourceSet(Cores(cores.doubleValue), maxMemory)
         this.pickResources(availableResources = availableResources).map(_.cores)
       }.headOption
     }
@@ -106,7 +106,7 @@ trait Schedulable {
   private[tasksystem] def minMemory(start: Memory = StartMemory, end: Memory = EndMemory, step: Memory = StepMemory, maxCores: Cores = EndCores): Option[Memory] = {
     // first check that the search will succeed, then test a range of values for memory
     this.pickResources(availableResources = new ResourceSet(maxCores, end)).flatMap { _ =>
-      (start.value to end.value by step.value).flatMap { memory =>
+      Range.Long.inclusive(start.value, end.value, step.value).flatMap { memory =>
         val availableResources = new ResourceSet(maxCores, Memory(memory))
         this.pickResources(availableResources = availableResources).map(_.memory)
       }.headOption
@@ -115,8 +115,8 @@ trait Schedulable {
 
   /** A crude attempt at estimating the minimum resources by assuming a fixed ratio of memory per core. */
   private[tasksystem] def minCoresAndMemory(start: Cores = OneCore, end: Cores = EndCores, step: Cores = OneCore, memoryPerCore: Memory = MemoryPerCore): Option[ResourceSet] = {
-    (start.value to end.value by step.value).flatMap { cores =>
-      val availableResources = new ResourceSet(Cores(cores), Memory((memoryPerCore.value * cores).toLong))
+    Range.BigDecimal.inclusive(start.value, end.value, step.value).flatMap { cores =>
+      val availableResources = new ResourceSet(Cores(cores.doubleValue), Memory((memoryPerCore.value * cores).toLong))
       this.pickResources(availableResources = availableResources)
     }.headOption
   }

--- a/core/src/main/scala/dagr/core/tasksystem/Task.scala
+++ b/core/src/main/scala/dagr/core/tasksystem/Task.scala
@@ -63,9 +63,8 @@ object Task {
 
     // 1. find all tasks connected to this task
     val visited: mutable.Set[Task] = new mutable.HashSet[Task]()
-    val toVisit: mutable.Set[Task] = new mutable.HashSet[Task]() {
-      add(task)
-    }
+    val toVisit: mutable.Set[Task] = mutable.HashSet[Task](task)
+
     while (toVisit.nonEmpty) {
       val nextTask: Task = toVisit.head
       toVisit -= nextTask

--- a/core/src/main/scala/dagr/core/tasksystem/Task.scala
+++ b/core/src/main/scala/dagr/core/tasksystem/Task.scala
@@ -164,10 +164,10 @@ trait Task extends Dependable {
   private val dependedOnByTasks = new ListBuffer[Task]()
 
   /** Gets the sequence of tasks that this task depends on.. */
-  protected[core] def tasksDependedOn: Traversable[Task] = this.dependsOnTasks.toList
+  protected[core] def tasksDependedOn: Iterable[Task] = this.dependsOnTasks.toList
 
   /** Gets the sequence of tasks that depend on this task. */
-  protected[core] def tasksDependingOnThisTask: Traversable[Task] = this.dependedOnByTasks.toList
+  protected[core] def tasksDependingOnThisTask: Iterable[Task] = this.dependedOnByTasks.toList
 
   /** Must be implemented to handle the addition of a dependent. */
   override def addDependent(dependent: Dependable): Unit = dependent.headTasks.foreach(t => {
@@ -178,9 +178,9 @@ trait Task extends Dependable {
   /** Removes this as a dependency for other */
   override def !=>(other: Dependable): Unit = other.headTasks.foreach(_.removeDependency(this))
 
-  override def headTasks: Traversable[Task] = Seq(this)
-  override def tailTasks: Traversable[Task] = Seq(this)
-  override def allTasks: Traversable[Task]  = Seq(this)
+  override def headTasks: Iterable[Task] = Seq(this)
+  override def tailTasks: Iterable[Task] = Seq(this)
+  override def allTasks: Iterable[Task]  = Seq(this)
 
   /**
      * Removes a dependency by removing the supplied task from the list of dependencies for this task
@@ -213,7 +213,7 @@ trait Task extends Dependable {
    *
    * @return the list of tasks of to run.
    */
-  def getTasks: Traversable[_ <: Task]
+  def getTasks: Iterable[_ <: Task]
 
   /** Finalize anything after the task has been run.
    *

--- a/core/src/main/scala/dagr/core/tasksystem/UnitTask.scala
+++ b/core/src/main/scala/dagr/core/tasksystem/UnitTask.scala
@@ -54,5 +54,5 @@ trait UnitTask extends Task with LazyLogging with Schedulable {
     * necessary last-minute configuration with the knowledge of the exact set of resources
     * they are to be run with.
     */
-  override def applyResources(resources: ResourceSet): Unit = Unit
+  override def applyResources(resources: ResourceSet): Unit = ()
 }

--- a/core/src/main/scala/dagr/core/tasksystem/UnitTask.scala
+++ b/core/src/main/scala/dagr/core/tasksystem/UnitTask.scala
@@ -45,7 +45,7 @@ trait UnitTask extends Task with LazyLogging with Schedulable {
     *
     * @return the list of tasks of to run.
     */
-  final def getTasks: Traversable[_ <: this.type] = {
+  final def getTasks: Iterable[_ <: this.type] = {
     List(this)
   }
 

--- a/core/src/test/scala/dagr/core/cmdline/DagrScriptManagerTest.scala
+++ b/core/src/test/scala/dagr/core/cmdline/DagrScriptManagerTest.scala
@@ -27,12 +27,11 @@ package dagr.core.cmdline
 import java.io.PrintWriter
 import java.nio.file.{Files, Path}
 
+import com.fulcrumgenomics.commons.CommonsDef._
 import com.fulcrumgenomics.commons.util.ClassFinder
 import dagr.core.UnitSpec
 import dagr.core.tasksystem.Pipeline
 import org.reflections.util.ClasspathHelper
-
-import scala.collection.JavaConversions._
 
 object DagrScriptManagerTest {
   def packageName: String = "dagr.example"
@@ -97,14 +96,14 @@ class DagrScriptManagerTest extends UnitSpec {
     manager.loadScripts(Seq(tmpFile), tmpDir)
 
     // make sure tmpDir is not on the classpath
-    ClasspathHelper.forManifest.toSet.exists(url => url.toString.contains(tmpDir.toString)) shouldBe true
+    ClasspathHelper.forManifest.iterator.toSet.exists(url => url.toString.contains(tmpDir.toString)) shouldBe true
 
     // make sure we find the class in the classpath
     val classFinder: ClassFinder = new ClassFinder
     classFinder.find("dagr.example", classOf[Pipeline])
     classFinder
       .getClasses
-      .toList
+      .iterator
       .map(_.getCanonicalName)
       .exists(name => 0 == name.compareTo("dagr.example.HelloWorldPipeline")) shouldBe true
 
@@ -117,6 +116,6 @@ class DagrScriptManagerTest extends UnitSpec {
     an[RuntimeException] should be thrownBy manager.loadScripts(Seq(tmpFile), tmpDir)
 
     // make sure tmpDir is not on the classpath
-    ClasspathHelper.forManifest.toSet.exists(url => url.toString.contains(tmpDir.toString)) shouldBe false
+    ClasspathHelper.forManifest.iterator.exists(url => url.toString.contains(tmpDir.toString)) shouldBe false
   }
 }

--- a/core/src/test/scala/dagr/core/cmdline/pipelines/Pipelines.scala
+++ b/core/src/test/scala/dagr/core/cmdline/pipelines/Pipelines.scala
@@ -35,7 +35,7 @@ private class TestGroup extends ClpGroup {
 
 @clp(description = "", group = classOf[TestGroup], hidden = true)
 private[cmdline] class CommandLineTaskTesting extends Pipeline {
-  override def build(): Unit = Unit
+  override def build(): Unit = ()
 }
 
 @clp(description = "", group = classOf[TestGroup], hidden = true)

--- a/core/src/test/scala/dagr/core/config/ConfigurationTest.scala
+++ b/core/src/test/scala/dagr/core/config/ConfigurationTest.scala
@@ -130,7 +130,7 @@ class ConfigurationTest extends UnitSpec with CaptureSystemStreams {
     val conf = new Configuration {  override val config : Config = ConfigFactory.parseFile(configPath.toFile) }
     conf.configure[String](Configuration.Keys.CommandLineName) shouldBe "command-line-name"
     conf.configure[Boolean](Configuration.Keys.ColorStatus) shouldBe false
-    conf.optionallyConfigure[String](Configuration.Keys.SystemPath) shouldBe 'empty
+    conf.optionallyConfigure[String](Configuration.Keys.SystemPath).isEmpty shouldBe true
   }
 
   it should "find executables" in {

--- a/core/src/test/scala/dagr/core/execsystem/NaiveSchedulerTest.scala
+++ b/core/src/test/scala/dagr/core/execsystem/NaiveSchedulerTest.scala
@@ -23,6 +23,7 @@
  */
 package dagr.core.execsystem
 
+import com.fulcrumgenomics.commons.CommonsDef._
 import com.fulcrumgenomics.commons.util.LazyLogging
 import dagr.core.tasksystem._
 import dagr.core.UnitSpec
@@ -186,7 +187,7 @@ class NaiveSchedulerTest extends UnitSpec with LazyLogging {
     val readyTasks = List(new HungryTask, new HungryTask, new HungryTask)
 
     val tupleOption = scheduler.scheduleOneTask(readyTasks, systemCores, systemMemory, jvmMemory)
-    tupleOption shouldBe 'defined
+    tupleOption.isDefined shouldBe true
     val resourceSet = tupleOption.get._2
     resourceSet.cores.value should be <= systemCores.value
   }

--- a/core/src/test/scala/dagr/core/execsystem/TaskExecutionRunnerTest.scala
+++ b/core/src/test/scala/dagr/core/execsystem/TaskExecutionRunnerTest.scala
@@ -149,7 +149,7 @@ class TaskExecutionRunnerTest extends UnitSpec with OptionValues with BeforeAndA
     runTaskAndComplete(task = task, taskId = taskId, taskInfo = taskInfo, taskStatus = TaskStatus.SUCCEEDED, exitCode = 0, onCompleteSuccessful = true)
   }
 
-  def runSimpleExitTest(inJvmTask: Boolean, exitSuccessfully: Boolean, onCompleteSuccessful: Boolean, failedAreCompleted: Boolean) {
+  def runSimpleExitTest(inJvmTask: Boolean, exitSuccessfully: Boolean, onCompleteSuccessful: Boolean, failedAreCompleted: Boolean): Unit = {
     val exitCode: Int = if (exitSuccessfully) 0 else 1
     val (task: UnitTask, taskId: TaskId, taskInfo: TaskExecutionInfo) = if (inJvmTask) {
       setupInJvmTaskList(exitCode = exitCode, taskId = 1)
@@ -277,7 +277,7 @@ class TaskExecutionRunnerTest extends UnitSpec with OptionValues with BeforeAndA
     runningTasks.head should be (taskId)
     taskInfo.status should be (TaskStatus.STARTED)
     val onCompleteSuccesful: Option[Boolean] = taskRunner.onCompleteSuccessful(taskId)
-    onCompleteSuccesful should be ('empty)
+    onCompleteSuccesful.isEmpty shouldBe true
 
     // the rest of the tests after this are just to make sure things work out and that we do not have a zombie process
 
@@ -356,7 +356,7 @@ class TaskExecutionRunnerTest extends UnitSpec with OptionValues with BeforeAndA
   it should "fail to run a task that is not a UnitTask" in  {
     val taskRunner: TaskExecutionRunner = new TaskExecutionRunner()
     val task = new Task {
-      override def getTasks: Traversable[_ <: Task] = Nil
+      override def getTasks: Iterable[_ <: Task] = Nil
     }
     val taskInfo = new TaskExecutionInfo(
       task = task,

--- a/core/src/test/scala/dagr/core/execsystem/TaskManagerTest.scala
+++ b/core/src/test/scala/dagr/core/execsystem/TaskManagerTest.scala
@@ -105,16 +105,16 @@ class TaskManagerTest extends UnitSpec with OptionValues with LazyLogging with B
     val task: UnitTask = new ShellCommand("exit", "0") withName "exit 0" requires ResourceSet.empty
     val taskManager: TestTaskManager = getDefaultTaskManager()
     taskManager.addTask(task=task) shouldBe 0
-    taskManager.taskStatusFor(0) shouldBe 'defined
-    taskManager.taskStatusFor(1) shouldBe 'empty
+    taskManager.taskStatusFor(0).isDefined shouldBe true
+    taskManager.taskStatusFor(1).isEmpty shouldBe true
   }
 
   it should "get the graph node state for only tracked tasks" in {
     val task: UnitTask = new ShellCommand("exit", "0") withName "exit 0" requires ResourceSet.empty
     val taskManager: TestTaskManager = getDefaultTaskManager()
     taskManager.addTask(task=task) shouldBe 0
-    taskManager.graphNodeStateFor(0) shouldBe 'defined
-    taskManager.graphNodeStateFor(1) shouldBe 'empty
+    taskManager.graphNodeStateFor(0).isDefined shouldBe true
+    taskManager.graphNodeStateFor(1).isEmpty shouldBe true
   }
 
   // ******************************************
@@ -274,7 +274,7 @@ class TaskManagerTest extends UnitSpec with OptionValues with LazyLogging with B
   def doTryAgain(original: Task,
                  replacement: Task,
                  replaceTask: Boolean = true,
-                 taskManager: TestTaskManager) {
+                 taskManager: TestTaskManager): Unit = {
 
     val (originalTaskStatus, originalGraphNodeState) = replaceTask match {
       case true => (TaskStatus.UNKNOWN, GraphNodeState.NO_PREDECESSORS)
@@ -291,7 +291,7 @@ class TaskManagerTest extends UnitSpec with OptionValues with LazyLogging with B
       // replace
       logger.debug("*** REPLACING TASK ***")
       taskManager.replaceTask(original = original, replacement = replacement)
-      original._taskInfo shouldBe 'empty
+      original._taskInfo.isEmpty shouldBe true
     }
     else {
       // resubmit...
@@ -627,7 +627,7 @@ class TaskManagerTest extends UnitSpec with OptionValues with LazyLogging with B
     taskManager.addTasks(leftA, leftB, rightB, finalTask)
 
     // run it until we cannot run any more tasks
-    taskManager.graphNodeStateFor(rightA) should be ('empty)
+    taskManager.graphNodeStateFor(rightA).isEmpty shouldBe true
     taskManager.graphNodeStateFor(rightB).value should be(GraphNodeState.ORPHAN)
     taskManager.stepExecution()
     taskManager.joinOnRunningTasks(1000)
@@ -719,8 +719,8 @@ class TaskManagerTest extends UnitSpec with OptionValues with LazyLogging with B
     taskManager.graphNodeStateFor(predecessorWorkflow).value should be(GraphNodeState.ONLY_PREDECESSORS)
     taskManager.graphNodeStateFor(predecessorWorkflow.firstTask).value should be(GraphNodeState.RUNNING)
     taskManager.graphNodeStateFor(predecessorWorkflow.secondTask).value should be(GraphNodeState.RUNNING)
-    taskManager.taskStatusFor(successorWorkflow.firstTask) should be('empty)
-    taskManager.taskStatusFor(successorWorkflow.secondTask) should be('empty)
+    taskManager.taskStatusFor(successorWorkflow.firstTask).isEmpty shouldBe true
+    taskManager.taskStatusFor(successorWorkflow.secondTask).isEmpty shouldBe true
     taskManager.taskStatusFor(successorWorkflow).value should be(TaskStatus.UNKNOWN)
     taskManager.graphNodeStateFor(successorWorkflow).value should be(GraphNodeState.PREDECESSORS_AND_UNEXPANDED)
 
@@ -902,10 +902,10 @@ class TaskManagerTest extends UnitSpec with OptionValues with LazyLogging with B
   private def getAndTestTaskExecutionInfo(taskManager: TestTaskManager, task: Task): TaskExecutionInfo = {
     // make sure the execution info and timestamps are set for this taske
     val info = taskManager.taskExecutionInfoFor(task)
-    info shouldBe 'defined
-    info.get.submissionDate shouldBe 'defined
-    info.get.startDate shouldBe 'defined
-    info.get.endDate shouldBe 'defined
+    info.isDefined shouldBe true
+    info.get.submissionDate.isDefined shouldBe true
+    info.get.startDate.isDefined shouldBe true
+    info.get.endDate.isDefined shouldBe true
     info.get
   }
 
@@ -988,7 +988,7 @@ class TaskManagerTest extends UnitSpec with OptionValues with LazyLogging with B
 
   private class ParentFailTask extends Task {
     val child: Task = new ShellCommand("exit", "1")
-    override def getTasks: Traversable[_ <: Task] = Seq(child)
+    override def getTasks: Iterable[_ <: Task] = Seq(child)
   }
 
   it should "mark a task as failed when one of its children fails" in {

--- a/core/src/test/scala/dagr/core/execsystem/TopLikeStatusReporterTest.scala
+++ b/core/src/test/scala/dagr/core/execsystem/TopLikeStatusReporterTest.scala
@@ -73,7 +73,7 @@ class TopLikeStatusReporterTest extends UnitSpec with CaptureSystemStreams with 
     val reporter = new TopLikeStatusReporter(taskManager = taskManager, print = (str: String) => output.append(str)) with TestTerminal
     reporter.start()
     reporter.shutdown()
-    output should not be 'empty
+    output.isEmpty shouldBe false
   }
 
   it should "start and shutdown cleanly when no tasks are being managed with a two line terminal" in {
@@ -82,7 +82,7 @@ class TopLikeStatusReporterTest extends UnitSpec with CaptureSystemStreams with 
     val reporter = new TopLikeStatusReporter(taskManager = taskManager, print = (str: String) => output.append(str)) with TwoLineTestTerminal
     reporter.start()
     reporter.shutdown()
-    output should not be 'empty
+    output.isEmpty shouldBe false
     output.toString() should include("with 4 more lines not shown")
   }
 
@@ -94,7 +94,7 @@ class TopLikeStatusReporterTest extends UnitSpec with CaptureSystemStreams with 
     taskManager.addTask(new NoOpInJvmTask("Exit0Task"))
     taskManager.runToCompletion(failFast=true)
     reporter.shutdown()
-    output should not be 'empty
+    output.isEmpty shouldBe false
     output.toString() should include("Exit0Task")
     output.toString() should include("1 Done")
   }
@@ -112,7 +112,7 @@ class TopLikeStatusReporterTest extends UnitSpec with CaptureSystemStreams with 
     taskManager.addTask(taskOne)
     taskManager.runToCompletion(failFast=true)
     reporter.refresh(print=printMethod)
-    output should not be 'empty
+    output.isEmpty shouldBe false
     output.toString() should include("TaskOne")
     output.toString() should include("0 Running")
     output.toString() should include("1 Failed")
@@ -134,7 +134,7 @@ class TopLikeStatusReporterTest extends UnitSpec with CaptureSystemStreams with 
       taskManager.stepExecution()
     }
     reporter.refresh(print=printMethod)
-    output should not be 'empty
+    output.isEmpty shouldBe false
     output.toString() should include("TaskOne")
     output.toString() should include("1 Running")
     output.toString() should include("0 Done")
@@ -142,7 +142,7 @@ class TopLikeStatusReporterTest extends UnitSpec with CaptureSystemStreams with 
 
     taskManager.runToCompletion(failFast=true)
     reporter.refresh(print=printMethod)
-    output should not be 'empty
+    output.isEmpty shouldBe false
     output.toString() should include("TaskOne")
     output.toString() should include("0 Running")
     output.toString() should include("1 Done")
@@ -169,7 +169,7 @@ class TopLikeStatusReporterTest extends UnitSpec with CaptureSystemStreams with 
       taskManager.stepExecution()
     }
     reporter.refresh(print=printMethod)
-    output should not be 'empty
+    output.isEmpty shouldBe false
     output.toString() should include("TaskOne")
     output.toString() should include("TaskTwo")
     output.toString() should include("1 Running")
@@ -180,7 +180,7 @@ class TopLikeStatusReporterTest extends UnitSpec with CaptureSystemStreams with 
 
     taskManager.runToCompletion(failFast=true)
     reporter.refresh(print=printMethod)
-    output should not be 'empty
+    output.isEmpty shouldBe false
     output.toString() should include("TaskOne")
     output.toString() should include("TaskTwo")
     output.toString() should include("0 Running")
@@ -205,7 +205,7 @@ class TopLikeStatusReporterTest extends UnitSpec with CaptureSystemStreams with 
       taskManager.stepExecution()
     }
     reporter.refresh(print=printMethod)
-    output should not be 'empty
+    output.isEmpty shouldBe false
     output.toString() should include("TaskOne")
     output.toString() should not include "TaskTwo"
     output.toString() should include("1 Running")
@@ -216,7 +216,7 @@ class TopLikeStatusReporterTest extends UnitSpec with CaptureSystemStreams with 
 
     taskManager.runToCompletion(failFast=true)
     reporter.refresh(print=printMethod)
-    output should not be 'empty
+    output.isEmpty shouldBe false
     output.toString() should include("TaskOne")
     output.toString() should include("TaskTwo")
     output.toString() should include("0 Running")

--- a/core/src/test/scala/dagr/core/tasksystem/RetryTest.scala
+++ b/core/src/test/scala/dagr/core/tasksystem/RetryTest.scala
@@ -50,7 +50,7 @@ class RetryTest extends UnitSpec with OptionValues {
 
     val task = new Task with LinearMemoryRetry {
       requires(1, from)
-      override def applyResources(resources : ResourceSet): Unit = Unit
+      override def applyResources(resources : ResourceSet): Unit = ()
       def getTasks: Traversable[_ <: Task] = List.empty
       override def toMemory: Memory = Memory(to)
       override def byMemory: Memory = Memory(by)
@@ -74,7 +74,7 @@ class RetryTest extends UnitSpec with OptionValues {
 
     val task = new Task with MemoryDoublingRetry {
       requires(1, from)
-      override def applyResources(resources : ResourceSet): Unit = Unit
+      override def applyResources(resources : ResourceSet): Unit = ()
       def getTasks: Traversable[_ <: Task] = List.empty
     }
     Resource.parseBytesToSize(task.asInstanceOf[FixedResources].resources.memory.value) shouldBe "1024m"

--- a/core/src/test/scala/dagr/core/tasksystem/RetryTest.scala
+++ b/core/src/test/scala/dagr/core/tasksystem/RetryTest.scala
@@ -51,7 +51,7 @@ class RetryTest extends UnitSpec with OptionValues {
     val task = new Task with LinearMemoryRetry {
       requires(1, from)
       override def applyResources(resources : ResourceSet): Unit = ()
-      def getTasks: Traversable[_ <: Task] = List.empty
+      def getTasks: Iterable[_ <: Task] = List.empty
       override def toMemory: Memory = Memory(to)
       override def byMemory: Memory = Memory(by)
     }
@@ -75,7 +75,7 @@ class RetryTest extends UnitSpec with OptionValues {
     val task = new Task with MemoryDoublingRetry {
       requires(1, from)
       override def applyResources(resources : ResourceSet): Unit = ()
-      def getTasks: Traversable[_ <: Task] = List.empty
+      def getTasks: Iterable[_ <: Task] = List.empty
     }
     Resource.parseBytesToSize(task.asInstanceOf[FixedResources].resources.memory.value) shouldBe "1024m"
 
@@ -94,7 +94,7 @@ class RetryTest extends UnitSpec with OptionValues {
   "MultipleRetry" should "retry a fixed number of times" in {
     val task = new Task with MultipleRetry {
       def maxNumIterations: Int = 3
-      def getTasks: Traversable[_ <: Task] = List.empty
+      def getTasks: Iterable[_ <: Task] = List.empty
     }
     val info = taskInfo(task)
     task.retry(systemResources, info) shouldBe true

--- a/core/src/test/scala/dagr/core/tasksystem/SchedulableTest.scala
+++ b/core/src/test/scala/dagr/core/tasksystem/SchedulableTest.scala
@@ -32,7 +32,7 @@ import org.scalatest.OptionValues
 class SchedulableTest extends UnitSpec with OptionValues {
 
   private val fixedTask = new FixedResources {
-    override def applyResources(resources: ResourceSet) = Unit
+    override def applyResources(resources: ResourceSet) = ()
   }
 
   // A variable task that takes twice as much memory in GB as available cores.

--- a/core/src/test/scala/dagr/core/tasksystem/SchedulableTest.scala
+++ b/core/src/test/scala/dagr/core/tasksystem/SchedulableTest.scala
@@ -59,64 +59,64 @@ class SchedulableTest extends UnitSpec with OptionValues {
   "Schedulable.minCores" should "work with fixed resources" in {
     fixedTask.requires(1, "2g").minCores().value.value shouldBe 1
     fixedTask.requires(2, "2g").minCores().value.value shouldBe 2
-    fixedTask.requires(2, "2g").minCores(end=Cores(1)) shouldBe 'empty
-    fixedTask.requires(2, "2g").minCores(start=Cores(1), end=Cores(2), step=Cores(2)) shouldBe 'empty
+    fixedTask.requires(2, "2g").minCores(end=Cores(1)).isEmpty shouldBe true
+    fixedTask.requires(2, "2g").minCores(start=Cores(1), end=Cores(2), step=Cores(2)).isEmpty shouldBe true
   }
 
   it should "work with variable resources" in {
     doubleMemoryTask.minCores(end=Cores(1)).value.value shouldBe 1
     doubleMemoryTask.minCores(start=Cores(2), end=Cores(2), step=Cores(1)).value.value shouldBe 2
-    doubleMemoryTask.minCores(start=Cores(3), end=Cores(2), step=Cores(1)) shouldBe 'empty
+    doubleMemoryTask.minCores(start=Cores(3), end=Cores(2), step=Cores(1)).isEmpty shouldBe true
   }
 
   "Schedulable.minMemory" should "work with fixed resources" in {
     fixedTask.requires(1, "2g").minMemory().value shouldBe Memory("2g")
     fixedTask.requires(2, "2g").minMemory().value shouldBe Memory("2g")
-    fixedTask.requires(2, "2g").minMemory(end=Memory("1g")) shouldBe 'empty
-    fixedTask.requires(2, "2g").minMemory(start=Memory("1g"), end=Memory("2g"), step=Memory("2g")) shouldBe 'empty
+    fixedTask.requires(2, "2g").minMemory(end=Memory("1g")).isEmpty shouldBe true
+    fixedTask.requires(2, "2g").minMemory(start=Memory("1g"), end=Memory("2g"), step=Memory("2g")).isEmpty shouldBe true
   }
 
   it should "work with variable resources" in {
     twoGbTask.minMemory().value.value shouldBe Memory("2g").value
-    twoGbTask.minMemory(end=Memory("1g"), step=Memory("256m")) shouldBe 'empty
+    twoGbTask.minMemory(end=Memory("1g"), step=Memory("256m")).isEmpty shouldBe true
     twoGbTask.minMemory(end=Memory("2g"), step=Memory("256m")).value.value shouldBe Memory("2g").value
     twoGbTask.minMemory(start=Memory("1g"), end=Memory("2g"), step=Memory("1g")).value.value shouldBe Memory("2g").value
-    twoGbTask.minMemory(start=Memory("3g"), end=Memory("2g"), step=Memory("1g")) shouldBe 'empty
+    twoGbTask.minMemory(start=Memory("3g"), end=Memory("2g"), step=Memory("1g")).isEmpty shouldBe true
   }
 
   "Schedulable.minCoresAndMemory" should "work with fixed resources" in {
     fixedTask.requires(2, "2g").minCoresAndMemory(memoryPerCore=Memory("1g")).value shouldBe ResourceSet(Cores(2), Memory("2g"))
     fixedTask.requires(2, "1g").minCoresAndMemory(memoryPerCore=Memory("512m")).value shouldBe ResourceSet(Cores(2), Memory("1g"))
-    fixedTask.requires(2, "1g").minCoresAndMemory(memoryPerCore=Memory(Memory("1m").value / 2)) shouldBe 'empty
+    fixedTask.requires(2, "1g").minCoresAndMemory(memoryPerCore=Memory(Memory("1m").value / 2)).isEmpty shouldBe true
   }
 
   it should "work with variable resources" in {
     doubleMemoryTask.minCoresAndMemory(memoryPerCore=Memory("4g")).value shouldBe ResourceSet(Cores(1), Memory("2g"))
     doubleMemoryTask.minCoresAndMemory(memoryPerCore=Memory("2g")).value shouldBe ResourceSet(Cores(1), Memory("2g"))
-    doubleMemoryTask.minCoresAndMemory(memoryPerCore=Memory("1g")) shouldBe 'empty
+    doubleMemoryTask.minCoresAndMemory(memoryPerCore=Memory("1g")).isEmpty shouldBe true
 
     quadMemoryTask.minCoresAndMemory(memoryPerCore=Memory("4g")).value shouldBe ResourceSet(Cores(1), Memory("4g"))
-    quadMemoryTask.minCoresAndMemory(memoryPerCore=Memory("2g")) shouldBe 'empty
-    quadMemoryTask.minCoresAndMemory(memoryPerCore=Memory("1g")) shouldBe 'empty
+    quadMemoryTask.minCoresAndMemory(memoryPerCore=Memory("2g")).isEmpty shouldBe true
+    quadMemoryTask.minCoresAndMemory(memoryPerCore=Memory("1g")).isEmpty shouldBe true
   }
 
   "Schedulable.minResources" should "work with fixed resources" in {
     fixedTask.requires(1, "2g").minResources().value shouldBe ResourceSet(Cores(1), Memory("2g"))
     fixedTask.requires(2, "24g").minResources().value shouldBe ResourceSet(Cores(2), Memory("24g"))
-    fixedTask.requires(2, "24g").minResources(maximumResources=ResourceSet(Cores(1), Memory("24g"))) shouldBe 'empty
+    fixedTask.requires(2, "24g").minResources(maximumResources=ResourceSet(Cores(1), Memory("24g"))).isEmpty shouldBe true
   }
 
   it should "work with variable resources" in {
     twoGbTask.minResources().value shouldBe ResourceSet(Cores(1), Memory("2g"))
     twoGbTask.minResources(ResourceSet(Cores(2), Memory("2g"))).value shouldBe ResourceSet(Cores(1), Memory("2g"))
     twoGbTask.minResources(ResourceSet(Cores(2), Memory("1g"))).value shouldBe ResourceSet(Cores(2), Memory("2g"))
-    twoGbTask.minResources(ResourceSet(Cores(2), Memory("1023m"))) shouldBe 'empty
+    twoGbTask.minResources(ResourceSet(Cores(2), Memory("1023m"))).isEmpty shouldBe true
 
     doubleMemoryTask.minResources().value shouldBe ResourceSet(Cores(1), Memory("2g"))
-    doubleMemoryTask.minResources(ResourceSet(Cores(2), Memory("1g"))) shouldBe 'empty
+    doubleMemoryTask.minResources(ResourceSet(Cores(2), Memory("1g"))).isEmpty shouldBe true
 
     quadMemoryTask.minResources().value shouldBe ResourceSet(Cores(1), Memory("4g"))
     quadMemoryTask.minResources(ResourceSet(Cores(1), Memory("4g"))).value shouldBe ResourceSet(Cores(1), Memory("4g"))
-    quadMemoryTask.minResources(ResourceSet(Cores(1), Memory("3g"))) shouldBe 'empty
+    quadMemoryTask.minResources(ResourceSet(Cores(1), Memory("3g"))).isEmpty shouldBe true
   }
 }

--- a/core/src/test/scala/dagr/core/tasksystem/TaskTest.scala
+++ b/core/src/test/scala/dagr/core/tasksystem/TaskTest.scala
@@ -41,7 +41,7 @@ class TaskTest extends UnitSpec with LazyLogging {
   class LazyTask(var sleepTime: Option[SleepAndExitData]) extends ProcessTask {
     name = "LazyTask"
     private val argBuffer = ListBuffer[Any]()
-    override def args = argBuffer
+    override def args = argBuffer.toSeq
     override def pickResources(availableResources: ResourceSet): Option[ResourceSet] = Some(ResourceSet.empty)
 
     override def applyResources(resources: ResourceSet): Unit = {

--- a/core/src/test/scala/dagr/core/tasksystem/TaskTest.scala
+++ b/core/src/test/scala/dagr/core/tasksystem/TaskTest.scala
@@ -88,7 +88,7 @@ class TaskTest extends UnitSpec with LazyLogging {
 
       // so now lazyTask depends on the number from firstTask being not None
       firstTask.applyResources(ResourceSet.infinite)
-      firstTask.sleepTime should be ('defined)
+      firstTask.sleepTime.isDefined shouldBe true
       firstTask.tasksDependingOnThisTask.foreach(t => t.asInstanceOf[InJvmTask].inJvmMethod())
       lazyTask.getTasks should have size 1
     }
@@ -115,7 +115,7 @@ class TaskTest extends UnitSpec with LazyLogging {
       firstTask.getTasks should have size 1
       firstTask.sleepTime should be (None)
       firstTask.onComplete(0) should be (true)
-      firstTask.sleepTime should be ('defined)
+      firstTask.sleepTime.isDefined shouldBe true
       firstTask.tasksDependingOnThisTask.foreach(t => t.asInstanceOf[InJvmTask].inJvmMethod())
       lazyTask.getTasks should have size 1
     }
@@ -224,24 +224,24 @@ class TaskTest extends UnitSpec with LazyLogging {
       a ==> (b :: c :: d) ==> e ==> (f :: g)
 
       a.tasksDependedOn.isEmpty shouldBe true
-      a.tasksDependingOnThisTask should contain theSameElementsAs Traversable(b, c, d)
+      a.tasksDependingOnThisTask should contain theSameElementsAs Iterable(b, c, d)
 
-      b.tasksDependedOn should contain theSameElementsAs Traversable(a)
-      b.tasksDependingOnThisTask should contain theSameElementsAs Traversable(e)
+      b.tasksDependedOn should contain theSameElementsAs Iterable(a)
+      b.tasksDependingOnThisTask should contain theSameElementsAs Iterable(e)
 
-      c.tasksDependedOn should contain theSameElementsAs Traversable(a)
-      c.tasksDependingOnThisTask should contain theSameElementsAs Traversable(e)
+      c.tasksDependedOn should contain theSameElementsAs Iterable(a)
+      c.tasksDependingOnThisTask should contain theSameElementsAs Iterable(e)
 
-      d.tasksDependedOn should contain theSameElementsAs Traversable(a)
-      d.tasksDependingOnThisTask should contain theSameElementsAs Traversable(e)
+      d.tasksDependedOn should contain theSameElementsAs Iterable(a)
+      d.tasksDependingOnThisTask should contain theSameElementsAs Iterable(e)
 
-      e.tasksDependedOn should contain theSameElementsAs Traversable(b, c, d)
-      e.tasksDependingOnThisTask should contain theSameElementsAs Traversable(f, g)
+      e.tasksDependedOn should contain theSameElementsAs Iterable(b, c, d)
+      e.tasksDependingOnThisTask should contain theSameElementsAs Iterable(f, g)
 
-      f.tasksDependedOn should contain theSameElementsAs Traversable(e)
+      f.tasksDependedOn should contain theSameElementsAs Iterable(e)
       f.tasksDependingOnThisTask.isEmpty shouldBe true
 
-      g.tasksDependedOn should contain theSameElementsAs Traversable(e)
+      g.tasksDependedOn should contain theSameElementsAs Iterable(e)
       g.tasksDependingOnThisTask.isEmpty shouldBe true
 
       a !=> (b :: c :: d)
@@ -257,24 +257,24 @@ class TaskTest extends UnitSpec with LazyLogging {
       a :: b ==> c :: d ==> e :: f :: g
 
       a.tasksDependedOn.isEmpty shouldBe true
-      a.tasksDependingOnThisTask should contain theSameElementsAs Traversable(c, d)
+      a.tasksDependingOnThisTask should contain theSameElementsAs Iterable(c, d)
 
       b.tasksDependedOn.isEmpty shouldBe true
-      b.tasksDependingOnThisTask should contain theSameElementsAs Traversable(c, d)
+      b.tasksDependingOnThisTask should contain theSameElementsAs Iterable(c, d)
 
-      c.tasksDependedOn should contain theSameElementsAs Traversable(a, b)
-      c.tasksDependingOnThisTask should contain theSameElementsAs Traversable(e, f, g)
+      c.tasksDependedOn should contain theSameElementsAs Iterable(a, b)
+      c.tasksDependingOnThisTask should contain theSameElementsAs Iterable(e, f, g)
 
-      d.tasksDependedOn should contain theSameElementsAs Traversable(a, b)
-      d.tasksDependingOnThisTask should contain theSameElementsAs Traversable(e, f, g)
+      d.tasksDependedOn should contain theSameElementsAs Iterable(a, b)
+      d.tasksDependingOnThisTask should contain theSameElementsAs Iterable(e, f, g)
 
-      e.tasksDependedOn should contain theSameElementsAs Traversable(c, d)
+      e.tasksDependedOn should contain theSameElementsAs Iterable(c, d)
       e.tasksDependingOnThisTask.isEmpty shouldBe true
 
-      f.tasksDependedOn should contain theSameElementsAs Traversable(c, d)
+      f.tasksDependedOn should contain theSameElementsAs Iterable(c, d)
       f.tasksDependingOnThisTask.isEmpty shouldBe true
 
-      g.tasksDependedOn should contain theSameElementsAs Traversable(c, d)
+      g.tasksDependedOn should contain theSameElementsAs Iterable(c, d)
       g.tasksDependingOnThisTask.isEmpty shouldBe true
 
       a :: b !=> c :: d

--- a/pipelines/src/main/scala/dagr/pipelines/DnaResequencingFromUnmappedBamPipeline.scala
+++ b/pipelines/src/main/scala/dagr/pipelines/DnaResequencingFromUnmappedBamPipeline.scala
@@ -27,17 +27,15 @@ package dagr.pipelines
 import java.nio.file.{Files, Path}
 
 import _root_.picard.analysis.CollectMultipleMetrics.Program
+import com.fulcrumgenomics.commons.io.{Io, PathUtil}
 import com.fulcrumgenomics.sopt._
 import dagr.core.cmdline._
-import dagr.core.tasksystem.{Linker, Pipeline, ProcessTask, Task}
-import com.fulcrumgenomics.commons.io.{Io, PathUtil}
+import dagr.core.tasksystem.{Linker, Pipeline, Task}
 import dagr.tasks.DagrDef
-import DagrDef._
+import dagr.tasks.DagrDef._
 import dagr.tasks.bwa.{Bwa, BwaBacktrack}
 import dagr.tasks.misc.CalculateDownsamplingProportion
 import dagr.tasks.picard._
-
-import scala.collection.mutable.ListBuffer
 
 object DnaResequencingFromUnmappedBamPipeline {
   final val SUMMARY =
@@ -77,9 +75,9 @@ class DnaResequencingFromUnmappedBamPipeline
 
     val mappedBam   = Files.createTempFile(tmp, "mapped.", ".bam")
     val dsMappedBam = Files.createTempFile(tmp, "mapped.ds.", ".bam")
-    val finalBam    = PathUtil.pathTo(prefix + ".bam")
-    val dsPrefix    = PathUtil.pathTo(prefix + ".ds")
-    val dsFinalBam  = PathUtil.pathTo(dsPrefix + ".bam")
+    val finalBam    = PathUtil.pathTo(s"${prefix}.bam")
+    val dsPrefix    = PathUtil.pathTo(s"${prefix}.ds")
+    val dsFinalBam  = PathUtil.pathTo(s"${dsPrefix}.bam")
 
     ///////////////////////////////////////////////////////////////////////
     // Run BWA mem, then do some downsampling
@@ -100,7 +98,7 @@ class DnaResequencingFromUnmappedBamPipeline
       programs=List(Program.CollectQualityYieldMetrics),
       ref=ref
     )
-    val calculateP = new CalculateDownsamplingProportion(PathUtil.pathTo(prefix + ".quality_yield_metrics.txt"), downsampleToReads)
+    val calculateP = new CalculateDownsamplingProportion(PathUtil.pathTo(s"${prefix}.quality_yield_metrics.txt"), downsampleToReads)
     val downsample = new DownsampleSam(in=mappedBam, out=dsMappedBam, proportion=1, accuracy=Some(0.00001))
     val linker     = Linker(calculateP, downsample){(cp, ds) => ds.proportion = cp.proportion}
     bwa ==> yieldMetrics ==> calculateP ==> linker ==> downsample

--- a/pipelines/src/main/scala/dagr/pipelines/DownsampleAndCallSomaticVariants.scala
+++ b/pipelines/src/main/scala/dagr/pipelines/DownsampleAndCallSomaticVariants.scala
@@ -26,18 +26,17 @@ package dagr.pipelines
 import java.text.DecimalFormat
 
 import _root_.picard.analysis.directed.HsMetrics
-import dagr.core.cmdline.Pipelines
-import com.fulcrumgenomics.sopt._
-import dagr.core.execsystem.{Cores, Memory}
-import dagr.tasks.DagrDef
-import DagrDef._
-import dagr.core.tasksystem.{Linker, NoOpInJvmTask, Pipeline, SimpleInJvmTask}
+import com.fulcrumgenomics.commons.CommonsDef._
 import com.fulcrumgenomics.commons.io.Io
+import com.fulcrumgenomics.sopt._
+import dagr.core.cmdline.Pipelines
+import dagr.core.execsystem.{Cores, Memory}
+import dagr.core.tasksystem.{Linker, NoOpInJvmTask, Pipeline, SimpleInJvmTask}
+import dagr.tasks.DagrDef
 import dagr.tasks.jeanluc.FilterBam
 import dagr.tasks.picard.{CollectHsMetrics, DownsampleSam, DownsamplingStrategy}
 import htsjdk.samtools.metrics.MetricsFile
 
-import scala.collection.JavaConversions._
 
 /**
   * Pipeline to downsample a Tumor to a specific median coverage level (per CollectHsMetrics)
@@ -51,12 +50,12 @@ import scala.collection.JavaConversions._
   group = classOf[Pipelines]
 )
 class DownsampleAndCallSomaticVariants
-( @arg(flag='t', doc="Tumor BAM file")                          val tumorBam:  PathToBam,
-  @arg(flag='n', doc="Normal BAM file")                         val normalBam: PathToBam,
-  @arg(flag='r', doc="Reference FASTA file")                    val ref: PathToFasta,
-  @arg(flag='l', doc="Regions to call over")                    val intervals: PathToIntervals,
-  @arg(          doc="One or more coverage levels to call at.") val coverage:  Seq[Int],
-  @arg(flag='o', doc="Output directory")                        val output:    DirPath)
+(@arg(flag='t', doc="Tumor BAM file")                          val tumorBam:  DagrDef.PathToBam,
+ @arg(flag='n', doc="Normal BAM file")                         val normalBam: DagrDef.PathToBam,
+ @arg(flag='r', doc="Reference FASTA file")                    val ref: DagrDef.PathToFasta,
+ @arg(flag='l', doc="Regions to call over")                    val intervals: DagrDef.PathToIntervals,
+ @arg(          doc="One or more coverage levels to call at.") val coverage:  Seq[Int],
+ @arg(flag='o', doc="Output directory")                        val output:    DagrDef.DirPath)
   extends Pipeline(Some(output)) {
 
   override def build(): Unit = {

--- a/pipelines/src/main/scala/dagr/pipelines/DownsampleAndCallSomaticVariants.scala
+++ b/pipelines/src/main/scala/dagr/pipelines/DownsampleAndCallSomaticVariants.scala
@@ -32,7 +32,6 @@ import com.fulcrumgenomics.sopt._
 import dagr.core.cmdline.Pipelines
 import dagr.core.execsystem.{Cores, Memory}
 import dagr.core.tasksystem.{Linker, NoOpInJvmTask, Pipeline, SimpleInJvmTask}
-import dagr.tasks.DagrDef
 import dagr.tasks.jeanluc.FilterBam
 import dagr.tasks.picard.{CollectHsMetrics, DownsampleSam, DownsamplingStrategy}
 import htsjdk.samtools.metrics.MetricsFile
@@ -50,12 +49,12 @@ import htsjdk.samtools.metrics.MetricsFile
   group = classOf[Pipelines]
 )
 class DownsampleAndCallSomaticVariants
-(@arg(flag='t', doc="Tumor BAM file")                          val tumorBam:  DagrDef.PathToBam,
- @arg(flag='n', doc="Normal BAM file")                         val normalBam: DagrDef.PathToBam,
- @arg(flag='r', doc="Reference FASTA file")                    val ref: DagrDef.PathToFasta,
- @arg(flag='l', doc="Regions to call over")                    val intervals: DagrDef.PathToIntervals,
+(@arg(flag='t', doc="Tumor BAM file")                          val tumorBam:  PathToBam,
+ @arg(flag='n', doc="Normal BAM file")                         val normalBam: PathToBam,
+ @arg(flag='r', doc="Reference FASTA file")                    val ref: PathToFasta,
+ @arg(flag='l', doc="Regions to call over")                    val intervals: PathToIntervals,
  @arg(          doc="One or more coverage levels to call at.") val coverage:  Seq[Int],
- @arg(flag='o', doc="Output directory")                        val output:    DagrDef.DirPath)
+ @arg(flag='o', doc="Output directory")                        val output:    DirPath)
   extends Pipeline(Some(output)) {
 
   override def build(): Unit = {

--- a/pipelines/src/main/scala/dagr/pipelines/GermlineVariantCallingPipeline.scala
+++ b/pipelines/src/main/scala/dagr/pipelines/GermlineVariantCallingPipeline.scala
@@ -96,7 +96,7 @@ class GermlineVariantCallingPipeline
     // Run variant calling metrics
     dbsnp match {
       case Some(db) => vc ==> new CollectVariantCallingMetrics(vcf=finalVcf, prefix=out, dbsnp=db, intervals=intervals)
-      case _ => Unit
+      case _        => ()
     }
 
     // Perform variant assessment
@@ -131,7 +131,7 @@ class GermlineVariantCallingPipeline
 
         // Update the dependencies
         vc ==> (getCallSampleName :: getTruthSampleName) ==> concordance
-      case None => Unit
+      case None => ()
     }
   }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += Resolver.url("fix-sbt-plugin-releases", url("http://dl.bintray.com/
 addSbtPlugin("com.typesafe.sbt"  % "sbt-git"       % "0.9.3")
 addSbtPlugin("com.github.gseitz" % "sbt-release"   % "1.0.6")
 addSbtPlugin("com.eed3si9n"      % "sbt-assembly"  % "0.14.6")
-addSbtPlugin("org.scoverage"     % "sbt-scoverage" % "1.5.1")
+addSbtPlugin("org.scoverage"     % "sbt-scoverage" % "1.6.0")
 addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype"  % "2.2")
 addSbtPlugin("com.jsuereth"      % "sbt-pgp"       % "1.1.0")
 addSbtPlugin("net.virtual-void"  % "sbt-dependency-graph" % "0.9.0")

--- a/tasks/src/main/scala/dagr/tasks/JarTask.scala
+++ b/tasks/src/main/scala/dagr/tasks/JarTask.scala
@@ -51,7 +51,7 @@ object JarTask {
 trait JarTask {
 
   protected def jarArgs(jarPath: Path,
-                        jvmArgs: Traversable[String] = Nil,
+                        jvmArgs: Iterable[String] = Nil,
                         jvmProperties: collection.Map[String,String] = Map.empty,
                         jvmMemory: Memory,
                         useAdvancedGcOptions: Boolean = true): List[String] = {

--- a/tasks/src/main/scala/dagr/tasks/ScatterGather.scala
+++ b/tasks/src/main/scala/dagr/tasks/ScatterGather.scala
@@ -109,7 +109,7 @@ object ScatterGather {
 
   /** Implementation of a Gather that performs a single All->One gather operation. */
   private class SingleGather[Source, Result <: Task](f: Seq[Source] => Result) extends Gather[Source,Result] {
-    override def getTasks: Traversable[_ <: Task] = sources match {
+    override def getTasks: Iterable[_ <: Task] = sources match {
       case None    => throw new IllegalStateException("Gather.getTasks called before sources populated.")
       case Some(a) => Some(f(a))
     }
@@ -121,7 +121,7 @@ object ScatterGather {
   */
   private class PartitionerWrapper[Result](val partitioner: Partitioner[Result]) extends Scatter[Result] {
 
-    override def getTasks: Traversable[_ <: Task] = Some(partitioner)
+    override def getTasks: Iterable[_ <: Task] = Some(partitioner)
 
     override def gather[NextResult <: Task](f: Seq[Result] => NextResult): Gather[Result,NextResult] =
       throw new UnsupportedOperationException("gather not supported on an unmapped Scatter")
@@ -232,7 +232,7 @@ object ScatterGather {
       subs.foreach { sub => sub.chain(task).foreach { s => task ==> s } }
       Seq(task)
     }
-    override def getTasks: Traversable[_ <: Task] =
+    override def getTasks: Iterable[_ <: Task] =
       throw new UnsupportedOperationException("getTasks is not supported and should never be called on sub-scatters.")
   }
 

--- a/tasks/src/main/scala/dagr/tasks/bwa/Bwa.scala
+++ b/tasks/src/main/scala/dagr/tasks/bwa/Bwa.scala
@@ -51,7 +51,7 @@ object Bwa extends Configuration {
                      processAltMappings: Boolean = false,
                      orientation: PairOrientation = PairOrientation.FR
                     ): Pipe[SamOrBam,SamOrBam] = {
-    val alt = PathUtil.pathTo(ref + ".alt")
+    val alt = PathUtil.pathTo(s"${ref}.alt")
     val doAlt = Files.exists(alt) && processAltMappings
     val fifoMem: Memory = Memory(fifoBufferMem)
 

--- a/tasks/src/main/scala/dagr/tasks/bwa/BwaBacktrack.scala
+++ b/tasks/src/main/scala/dagr/tasks/bwa/BwaBacktrack.scala
@@ -85,7 +85,7 @@ class BwaAln(val in: PathToFastq, val out: FilePath, val ref: PathToFasta, val m
     seedLength.foreach(args.append("-l", _))
     if (Io.StdOut  != out) args.append("-f", out.toString)
     args.append(ref, in)
-    args
+    args.toSeq
   }
 }
 
@@ -101,7 +101,7 @@ class BwaSampe(val r1Fastq: PathToFastq, val r2Fastq: PathToFastq,
     args.append(Bwa.findBwa.toString, "sampe", "-P")
     if (Io.StdOut  != out) args.append("-f", out)
     args.append(ref, r1Sai, r2Sai, r1Fastq, r2Fastq)
-    args
+    args.toSeq
   }
 }
 
@@ -114,10 +114,9 @@ class BwaSamse(val r1Fastq: PathToFastq,
   requires(new ResourceSet(Cores(1), Memory("6g")))
 
   override def args: Seq[Any] = {
-    val args = ListBuffer[Any]()
-    args.append(Bwa.findBwa.toString, "samse")
+    val args = ListBuffer[Any](Bwa.findBwa.toString, "samse")
     if (Io.StdOut  != out) args.append("-f", out)
     args.append(ref, r1Sai, r1Fastq)
-    args
+    args.toSeq
   }
 }

--- a/tasks/src/main/scala/dagr/tasks/fgbio/ClipBam.scala
+++ b/tasks/src/main/scala/dagr/tasks/fgbio/ClipBam.scala
@@ -33,8 +33,6 @@ class ClipBam(val input: PathToBam,
               val output: PathToBam,
               val ref: PathToFasta,
               val metrics: Option[FilePath] = None,
-              @deprecated("Use clipping-mode instead.", since="0.2.1")
-              val softClip: Option[Boolean] = None,
               val clippingMode: Option[String] = None,
               val autoClipAttributes: Option[Boolean] = None,
               val upgradeClipping: Option[Boolean] = None,
@@ -45,14 +43,11 @@ class ClipBam(val input: PathToBam,
               val clipOverlappingReads: Option[Boolean] = None
              ) extends FgBioTask {
 
-  require(softClip.isEmpty || clippingMode.isEmpty, "Both softClip and clippingMode cannot both be used.")
-
   override protected def addFgBioArgs(buffer: ListBuffer[Any]): Unit = {
     buffer.append("-i", input)
     buffer.append("-o", output)
     buffer.append("-r", ref)
     metrics.foreach           (m => buffer.append("-m", m))
-    softClip.foreach          (s => buffer.append("-s", s))
     clippingMode.foreach      (c => buffer.append("-c", c))
     autoClipAttributes.foreach(a => buffer.append("-a", a))
     upgradeClipping.foreach   (u => buffer.append("--upgrade-clipping", u))

--- a/tasks/src/main/scala/dagr/tasks/fgbio/FgBioTask.scala
+++ b/tasks/src/main/scala/dagr/tasks/fgbio/FgBioTask.scala
@@ -67,7 +67,7 @@ abstract class FgBioTask(var compressionLevel: Option[Int] = None,
     logLevel.foreach(l => buffer.append("--log-level", l))
     buffer += commandName
     addFgBioArgs(buffer)
-    buffer
+    buffer.toSeq
   }
 
   /** Can be overridden to use a specific FgBio jar. */

--- a/tasks/src/main/scala/dagr/tasks/gatk/GatkTask.scala
+++ b/tasks/src/main/scala/dagr/tasks/gatk/GatkTask.scala
@@ -56,7 +56,7 @@ abstract class GatkTask(val walker: String,
     intervals.foreach(il => buffer.append("-L", il.toAbsolutePath.toString))
     bamCompression.foreach(c => buffer.append("--bam_compression", c))
     addWalkerArgs(buffer)
-    buffer
+    buffer.toSeq
   }
 
   /** Can be overridden to use a specific GATK jar. */

--- a/tasks/src/main/scala/dagr/tasks/misc/DeleteFiles.scala
+++ b/tasks/src/main/scala/dagr/tasks/misc/DeleteFiles.scala
@@ -26,10 +26,8 @@ package dagr.tasks.misc
 import java.nio.file.{Path, Files}
 import java.util.stream.Collectors
 
+import com.fulcrumgenomics.commons.CommonsDef._
 import dagr.core.tasksystem.SimpleInJvmTask
-import dagr.tasks.DagrDef
-import DagrDef.FilePath
- import scala.collection.JavaConversions._
 
 /**
   * Simple tasks that deletes one or more extent files. If a path represents a directory
@@ -47,7 +45,7 @@ class DeleteFiles(val paths: FilePath*) extends SimpleInJvmTask {
       val childStream = Files.list(path)
       val children = childStream.collect(Collectors.toList())
       childStream.close()
-      children.foreach(this.delete)
+      children.iterator.foreach(this.delete)
     }
 
     Files.deleteIfExists(path)

--- a/tasks/src/main/scala/dagr/tasks/misc/GetNumPfReads.scala
+++ b/tasks/src/main/scala/dagr/tasks/misc/GetNumPfReads.scala
@@ -25,11 +25,11 @@ package dagr.tasks.misc
 
 import java.nio.file.Path
 
+import com.fulcrumgenomics.commons.CommonsDef._
 import dagr.core.tasksystem.SimpleInJvmTask
 import htsjdk.samtools.metrics.MetricsFile
 import picard.analysis.AlignmentSummaryMetrics
 
-import scala.collection.JavaConversions._
 
 class GetNumPfReads(alignmentSummaryMetrics: Path) extends SimpleInJvmTask {
   var numPfReads: Long = 0

--- a/tasks/src/main/scala/dagr/tasks/misc/GetSampleNamesFromVcf.scala
+++ b/tasks/src/main/scala/dagr/tasks/misc/GetSampleNamesFromVcf.scala
@@ -24,14 +24,13 @@
 
 package dagr.tasks.misc
 
+import com.fulcrumgenomics.commons.CommonsDef._
 import dagr.core.tasksystem.SimpleInJvmTask
-import dagr.tasks.DagrDef
-import DagrDef.PathToVcf
+import dagr.tasks.DagrDef.PathToVcf
 import htsjdk.samtools.util.CloserUtil
 import htsjdk.variant.vcf.{VCFFileReader, VCFHeader}
-import scala.collection.mutable
 
-import scala.collection.JavaConversions._
+import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 
 /** Gets the sample names from a VCF */

--- a/tasks/src/main/scala/dagr/tasks/picard/MergeSamFiles.scala
+++ b/tasks/src/main/scala/dagr/tasks/picard/MergeSamFiles.scala
@@ -34,7 +34,7 @@ import scala.collection.mutable.ListBuffer
 /**
  * Task for running MergeSamFiles with one or more inputs.
  */
-class MergeSamFiles(in: Traversable[PathToBam], out: PathToBam, sortOrder: SortOrder, useAsyncIo: Boolean = false)
+class MergeSamFiles(in: Iterable[PathToBam], out: PathToBam, sortOrder: SortOrder, useAsyncIo: Boolean = false)
   extends PicardTask(createIndex = Some(sortOrder == SortOrder.coordinate), useAsyncIo=useAsyncIo) with PipeOut[SamOrBam] {
   override protected def addPicardArgs(buffer: ListBuffer[Any]): Unit = {
     in.foreach(p => buffer.append("INPUT=" + p))

--- a/tasks/src/main/scala/dagr/tasks/picard/PicardMetricsTask.scala
+++ b/tasks/src/main/scala/dagr/tasks/picard/PicardMetricsTask.scala
@@ -57,7 +57,7 @@ trait PicardMetricsTask {
    * the case of CollectGcBiasMetrics.
     */
   def metricsFile(extension: String, kind: PicardOutput.Value) : Path = {
-    PathUtil.pathTo(pathPrefix + extension + "." + kind.toString)
+    PathUtil.pathTo(s"${pathPrefix}${extension}.${kind}")
   }
 
   /** All Picard metric generating tools should define their own metrics extension. */

--- a/tasks/src/main/scala/dagr/tasks/picard/RevertSam.scala
+++ b/tasks/src/main/scala/dagr/tasks/picard/RevertSam.scala
@@ -24,10 +24,9 @@
 package dagr.tasks.picard
 
 import dagr.core.execsystem.{Cores, Memory}
-import dagr.tasks.DagrDef._
 import htsjdk.samtools.SAMFileHeader.SortOrder
 
-import scala.collection.JavaConversions._
+import com.fulcrumgenomics.commons.CommonsDef._
 import scala.collection.mutable.ListBuffer
 
 object RevertSam {

--- a/tasks/src/main/scala/dagr/tasks/samtools/SamtoolsTask.scala
+++ b/tasks/src/main/scala/dagr/tasks/samtools/SamtoolsTask.scala
@@ -38,7 +38,7 @@ abstract class SamtoolsTask(val command: String) extends ProcessTask with Config
     val buffer = ListBuffer[Any]()
     buffer.append(samtools, command)
     addSubcommandArgs(buffer)
-    buffer
+    buffer.toSeq
   }
 
   def addSubcommandArgs(buffer: ListBuffer[Any]): Unit

--- a/tasks/src/main/scala/dagr/tasks/vc/FilterFreeBayesCalls.scala
+++ b/tasks/src/main/scala/dagr/tasks/vc/FilterFreeBayesCalls.scala
@@ -78,7 +78,7 @@ class FilterFreeBayesCalls(val in: PathToVcf,
 
   override def applyResources(resources: ResourceSet): Unit = ()
 
-  override def getTasks: Traversable[_ <: Task] = {
+  override def getTasks: Iterable[_ <: Task] = {
     // Apply filters specific to somatic calling
     if (somatic) {
       // source: https://github.com/chapmanb/bcbio-nextgen/blob/60a0f3c4f8ec658f8c34d6bc77b23a90f47b45d6/bcbio/variation/freebayes.py#L250

--- a/tasks/src/main/scala/dagr/tasks/vc/FilterFreeBayesCalls.scala
+++ b/tasks/src/main/scala/dagr/tasks/vc/FilterFreeBayesCalls.scala
@@ -76,7 +76,7 @@ class FilterFreeBayesCalls(val in: PathToVcf,
 
   requires(1.0, "2G")
 
-  override def applyResources(resources: ResourceSet): Unit = Unit
+  override def applyResources(resources: ResourceSet): Unit = ()
 
   override def getTasks: Traversable[_ <: Task] = {
     // Apply filters specific to somatic calling
@@ -89,13 +89,13 @@ class FilterFreeBayesCalls(val in: PathToVcf,
     val decompressVcf = new ShellCommand(configureExecutableFromBinDirectory(BgzipBinConfigKey, "bgzip").toString, "-c", "-d", in.toAbsolutePath.toString) with PipeWithNoResources[Nothing, Vcf]
 
     // Remove low quality calls
-    val filterLowQualityCalls = new ShellCommand(configureExecutableFromBinDirectory(BcfToolsBinConfigKey, "bcftools").toString, "filter", "-i", """'ALT="<*>" || QUAL > 5'""") with PipeWithNoResources[Vcf, Vcf] discardError()
+    val filterLowQualityCalls = (new ShellCommand(configureExecutableFromBinDirectory(BcfToolsBinConfigKey, "bcftools").toString, "filter", "-i", """'ALT="<*>" || QUAL > 5'""") with PipeWithNoResources[Vcf, Vcf]).discardError()
 
     // fix ambiguous (IUPAC) reference base calls
     val fixAmbiguousIupacReferenceCalls = new ShellCommand("awk", """-F\t""",  "-v", """OFS=\t""",  """{if ($0 !~ /^#/) gsub(/[KMRYSWBVHDX]/, "N", $4) } { print }""") with PipeWithNoResources[Vcf, Vcf]
 
     // remove alternate alleles that are not called in any sample
-    val removeAlts = new ShellCommand(configureExecutableFromBinDirectory(BcfToolsBinConfigKey, "bcftools").toString, "view", "-a", "-") with PipeWithNoResources[Vcf, Vcf] discardError()
+    val removeAlts = (new ShellCommand(configureExecutableFromBinDirectory(BcfToolsBinConfigKey, "bcftools").toString, "view", "-a", "-") with PipeWithNoResources[Vcf, Vcf]).discardError()
 
     // remove calls with missing alternative alleles
     // source: https://github.com/chapmanb/bcbio-nextgen/blob/60a0f3c4f8ec658f8c34d6bc77b23a90f47b45d6/bcbio/variation/freebayes.py#L237
@@ -112,7 +112,7 @@ class FilterFreeBayesCalls(val in: PathToVcf,
 
     // standardizes the representation of variants using parsimony and left-alignment relative to the reference genome
     // See: http://genome.sph.umich.edu/wiki/Variant_Normalization
-    val leftAlign = new ShellCommand(configureExecutableFromBinDirectory(VtBinConfigKey, "vt").toString, "normalize", "-n", "-r", ref.toAbsolutePath.toString, "-q", "-") with PipeWithNoResources[Vcf, Vcf] discardError()
+    val leftAlign = (new ShellCommand(configureExecutableFromBinDirectory(VtBinConfigKey, "vt").toString, "normalize", "-n", "-r", ref.toAbsolutePath.toString, "-q", "-") with PipeWithNoResources[Vcf, Vcf]).discardError()
 
     // remove both duplicate and reference alternate alleles
     val removeDuplicateAlleles = new ShellCommand(configureExecutableFromBinDirectory(VcfLibBinConfigKey, "vcfuniqalleles").toString) with PipeWithNoResources[Vcf, Vcf]

--- a/tasks/src/main/scala/dagr/tasks/vc/FreeBayes.scala
+++ b/tasks/src/main/scala/dagr/tasks/vc/FreeBayes.scala
@@ -149,7 +149,7 @@ abstract class FreeBayes(val ref: PathToFasta,
   }
 
   /** Sets the arguments for FreeBayes.  For somatic calling, there should be two bams, a tumor bam then normal bam. */
-  override def getTasks: Traversable[_ <: Task] = {
+  override def getTasks: Iterable[_ <: Task] = {
     // Generates the regions on the fly
     val generateTargets = targetIntervals match {
       case None => // Split using the FASTA

--- a/tasks/src/main/scala/dagr/tasks/vc/Strelka.scala
+++ b/tasks/src/main/scala/dagr/tasks/vc/Strelka.scala
@@ -65,9 +65,9 @@ class Strelka(val tumor: PathToBam,
       override def args: Seq[Any] = Seq("make", "--directory=" + tmpdir, "-j", this.resources.cores.toInt)
 
       override def pickResources(availableResources: ResourceSet): Option[ResourceSet] = {
-        (maxThreads to minThreads by -1).toStream
+        (maxThreads to minThreads by -1).iterator
           .flatMap(c => availableResources.subset(Cores(c), memory = Memory(s"${c}G")))
-          .headOption
+          .buffered.headOption
       }
     }.withName("RunStrelka")
 

--- a/tasks/src/main/scala/dagr/tasks/vc/VarDictJava.scala
+++ b/tasks/src/main/scala/dagr/tasks/vc/VarDictJava.scala
@@ -166,7 +166,7 @@ private class VarDictJava(tumorBam: PathToBam,
     buffer.append("-th", resources.cores.toInt) // The number of threads.
     buffer.append(bed)
 
-    buffer
+    buffer.toSeq
   }
 }
 
@@ -220,7 +220,7 @@ private class Var2VcfPaired(tumorName: String,
     minimumSignalToNoiseRatio.foreach(buffer.append("-o", _)) // The minimum signal to noise, or the ratio of hi/(lo+0.5).
     minimumHomozygousAlleleFreq.foreach(buffer.append("-F", _)) // The minimum allele frequency to consider a variant as homozygous.
 
-    buffer
+    buffer.toSeq
   }
 }
 
@@ -263,7 +263,7 @@ private class Var2VcfValid(sampleName: String,
     if (!printEndTag) buffer.append("-E") // If set, do not print END tag.
     minimumSplitReadsForSv.foreach(buffer.append("-T", _)) // The minimum number of split reads for an SV call.
 
-    buffer
+    buffer.toSeq
   }
 }
 

--- a/tasks/src/main/scala/dagr/tasks/vc/VarDictJava.scala
+++ b/tasks/src/main/scala/dagr/tasks/vc/VarDictJava.scala
@@ -93,7 +93,7 @@ object VarDictJava extends Configuration {
   private[vc] def firstReadGroup(bam: PathToBam): Option[SAMReadGroupRecord] = {
     import com.fulcrumgenomics.commons.CommonsDef.javaIteratorAsScalaIterator
     val in = SamReaderFactory.make().open(bam)
-    yieldAndThen(in.getFileHeader.getReadGroups.iterator.toStream.headOption) { in.close() }
+    yieldAndThen(in.getFileHeader.getReadGroups.iterator.buffered.headOption) { in.close() }
   }
 
   /** Return the sample name from the first read group in a BAM.

--- a/tasks/src/test/scala/dagr/tasks/ScatterGatherTests.scala
+++ b/tasks/src/test/scala/dagr/tasks/ScatterGatherTests.scala
@@ -76,7 +76,7 @@ class ScatterGatherTests extends UnitSpec with LazyLogging with BeforeAndAfterAl
         lines.head
       }
       val words = line.split(' ')
-      val paths = words.map(_ => tmp())
+      val paths = words.map(_ => tmp()).toSeq
       words.zip(paths) foreach { case(word, path) => Io.writeLines(path, Seq(word))}
       this.partitions = Some(paths)
     }
@@ -244,7 +244,7 @@ class ScatterGatherTests extends UnitSpec with LazyLogging with BeforeAndAfterAl
   }
 
   private case class CountTasks(wordCount: Int, tasks: Seq[SimpleInJvmTask], output: Path) extends SimpleInJvmTask  {
-    def run(): Unit = Io.writeLines(output, Seq(wordCount + " " + tasks.length))
+    def run(): Unit = Io.writeLines(output, Seq(s"${wordCount} ${tasks.length}"))
   }
 
   private case class GatherWordCounts(tasks: Seq[CountTasks], output: Path) extends SimpleInJvmTask  {


### PR DESCRIPTION
I've gotten rid of most of the deprecations except for one _huge_ class.  For some reason `Buffer.append(xs: A*)` got deprecated, and we use that literally everywhere in dagr.  To eliminate the deprecations we'd have to change e.g.:

`args.append("-i", in)`
to
`args.appendAll(Seq("-i", in))`
which just feels so much clunkier.  So I'm leaving it for now and am wondering if we should have our own arg-builder class that we use instead in some future release.