### PR TITLE
Add support for empty tasks

### DIFF
--- a/core/src/main/scala/dagr/core/tasksystem/Pipeline.scala
+++ b/core/src/main/scala/dagr/core/tasksystem/Pipeline.scala
@@ -84,4 +84,7 @@ abstract class Pipeline(val outputDirectory: Option[Path] = None,
 
   /** True if we this pipeline is tracking this direct ancestor task, false otherwise. */
   def contains(task: Task): Boolean = tasks.contains(task)
+
+  /** Builds an empty task for use within this pipeline. */
+  def emptyTask: Task = Task.empty
 }

--- a/core/src/main/scala/dagr/core/tasksystem/Task.scala
+++ b/core/src/main/scala/dagr/core/tasksystem/Task.scala
@@ -33,6 +33,15 @@ import scala.util.control.Breaks._
 /** Utility methods to aid in working with a task. */
 object Task {
 
+  /** Marker trait for empty tasks. */
+  sealed trait EmptyTask extends Task
+
+  /** A task that does nothing. */
+  def empty: Task = new EmptyTask {
+    name = "Task.empty"
+    override def getTasks: Iterable[_ <: Task] = None
+  }
+
   /** Helper class for Tarjan's strongly connected components algorithm */
   private class TarjanData {
     var index: Int = 0

--- a/core/src/test/scala/dagr/core/cmdline/DagrCoreMainTest.scala
+++ b/core/src/test/scala/dagr/core/cmdline/DagrCoreMainTest.scala
@@ -24,7 +24,7 @@
 
 package dagr.core.cmdline
 
-import dagr.core.cmdline.pipelines.PipelineFour
+import dagr.core.cmdline.pipelines.{PipelineFour, PipelineBuildFailure}
 import dagr.core.tasksystem.{NoOpInJvmTask, Pipeline}
 import com.fulcrumgenomics.commons.io.Io
 import com.fulcrumgenomics.sopt.util.TermCode
@@ -119,7 +119,7 @@ class DagrCoreMainTest extends UnitSpec with BeforeAndAfterAll with CaptureSyste
   }
 
   it should "print the execution failure upon failure" in {
-    val (_, _, _, log) = testParse(Array[String](nameOf(classOf[PipelineFour])))
+    val (_, _, _, log) = testParse(Array[String](nameOf(classOf[PipelineBuildFailure])))
     log should include("Elapsed time:")
     log should include("dagr failed")
   }

--- a/core/src/test/scala/dagr/core/cmdline/pipelines/Pipelines.scala
+++ b/core/src/test/scala/dagr/core/cmdline/pipelines/Pipelines.scala
@@ -57,3 +57,9 @@ private[cmdline] case class PipelineFour
 @clp(description = "", group = classOf[TestGroup], hidden = true)
 private[cmdline] case class PipelineWithMutex
 (@arg(mutex = Array("another")) var argument: String, @arg(mutex = Array("argument")) var another: String) extends CommandLineTaskTesting // argument should be required
+
+@clp(description = "", group = classOf[TestGroup], hidden = true)
+private[cmdline] case class PipelineBuildFailure
+(@arg var argument: String = "default", @arg var flag: Boolean = false) extends CommandLineTaskTesting {
+  override def build(): Unit = throw new IllegalStateException()
+}


### PR DESCRIPTION
1. `Tasks.getTasks` can now return an empty list of tasks to run (ex. `None`, `Seq.empty`) and the execution system will set the parent task to completed.  
2. Added a `Tasks$.empty` method to create a small task whose `getTasks` method returns `None`.