### PR TITLE
Use Files.deleteIfExists() in `DeleteBam` rather than `paths.filter(F…

### DIFF
--- a/tasks/src/main/scala/dagr/tasks/picard/DeleteBam.scala
+++ b/tasks/src/main/scala/dagr/tasks/picard/DeleteBam.scala
@@ -52,6 +52,6 @@ class DeleteBam(val bam: Path*) extends SimpleInJvmTask {
       }
     }
 
-    paths.filter(Files.exists(_)).foreach(Files.delete)
+    paths.foreach(Files.deleteIfExists)
   }
 }


### PR DESCRIPTION
…iles.exists).foreach(Files.delete)`.  The latter (previous implementation) was prone to throwing exceptions if there was a race to delete a given file.