### PR TITLE
Add withPrefix and withSuffix to Pipeline

### DIFF
--- a/core/src/main/scala/dagr/core/tasksystem/Pipeline.scala
+++ b/core/src/main/scala/dagr/core/tasksystem/Pipeline.scala
@@ -102,4 +102,10 @@ abstract class Pipeline(val outputDirectory: Option[Path] = None,
 
   /** Builds an empty task for use within this pipeline. */
   def emptyTask: Task = Task.empty
+
+  /** Sets the prefix of this pipeline. */
+  def withPrefix(prefix: String) : this.type = { this.prefix = Some(prefix); this }
+
+  /** Sets the suffix of this pipeline. */
+  def withSuffix(suffix: String) : this.type = { this.suffix = Some(suffix); this }
 }

--- a/core/src/test/scala/dagr/core/tasksystem/PipelineTest.scala
+++ b/core/src/test/scala/dagr/core/tasksystem/PipelineTest.scala
@@ -76,4 +76,36 @@ class PipelineTest extends UnitSpec {
     ts shouldBe List("outerbefore.innerbefore.hello.outerafter.innerafter",
                      "outerbefore.innerbefore.world.outerafter.innerafter")
   }
+
+  it should "add prefix when provided after construction" in {
+    class TestPipeline extends Pipeline {
+      override def build(): Unit = root ==> named("hello") ==> named("world")
+    }
+    val ts = new TestPipeline().withPrefix("new_prefix.").getTasks.map(_.name).toList.sorted
+    ts shouldBe List("new_prefix.hello", "new_prefix.world")
+  }
+
+  it should "change prefix when provided after construction" in {
+    class TestPipeline extends Pipeline(prefix=Some("before."), suffix=Some(".after")) {
+      override def build(): Unit = root ==> named("hello") ==> named("world")
+    }
+    val ts = new TestPipeline().withPrefix("new_prefix.").getTasks.map(_.name).toList.sorted
+    ts shouldBe List("new_prefix.hello.after", "new_prefix.world.after")
+  }
+
+  it should "add suffix when provided after construction" in {
+    class TestPipeline extends Pipeline {
+      override def build(): Unit = root ==> named("hello") ==> named("world")
+    }
+    val ts = new TestPipeline().withSuffix(".new_suffix").getTasks.map(_.name).toList.sorted
+    ts shouldBe List("hello.new_suffix", "world.new_suffix")
+  }
+
+  it should "change suffix when provided after construction" in {
+    class TestPipeline extends Pipeline(prefix=Some("before."), suffix=Some(".after")) {
+      override def build(): Unit = root ==> named("hello") ==> named("world")
+    }
+    val ts = new TestPipeline().withSuffix(".new_suffix").getTasks.map(_.name).toList.sorted
+    ts shouldBe List("before.hello.new_suffix", "before.world.new_suffix")
+  }
 }


### PR DESCRIPTION
I am suggesting adding the ability to change or set the prefix or suffix of a Pipeline at or after construction time. I believe it can help to make logs more readable. Modeled after `Task.withName`.