### PR TITLE
Expose `INCLUDE_SECONDARY_ALIGNMENTS` for MergeBamAlignment task.

### DIFF
--- a/tasks/src/main/scala/dagr/tasks/picard/MergeBamAlignment.scala
+++ b/tasks/src/main/scala/dagr/tasks/picard/MergeBamAlignment.scala
@@ -47,7 +47,8 @@ class MergeBamAlignment(unmapped: PathToBam,
                         orientation: PairOrientation = PairOrientation.FR,
                         maxGaps: Int = -1,
                         sortOrder: SortOrder = SortOrder.coordinate,
-                        useAlignerProperPairFlags: Boolean = false
+                        useAlignerProperPairFlags: Boolean = false,
+                        includeSecondaryAlignments: Boolean = true
                        )
   extends PicardTask with Pipe[SamOrBam,SamOrBam] {
   requires(Cores(1), Memory("4g"))
@@ -69,5 +70,6 @@ class MergeBamAlignment(unmapped: PathToBam,
     buffer.append("MAX_GAPS=" + maxGaps)
     buffer.append("SO=" + sortOrder.name())
     buffer.append("ALIGNER_PROPER_PAIR_FLAGS=" + useAlignerProperPairFlags)
+    buffer.append("INCLUDE_SECONDARY_ALIGNMENTS=" + includeSecondaryAlignments)
   }
 }


### PR DESCRIPTION
This currently defaults to true, but because of the following bug:
https://github.com/broadinstitute/picard/pull/932

Exposing this flag allows the secondary alignments to not be output and not fail while trying to calculate MD and NM flags.