### PR TITLE
Always use the logical processor count for system max cores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 
 # Build tool specific
 target
+
+# jEnv
+.java-version

--- a/core/src/main/scala/dagr/core/execsystem/Resource.scala
+++ b/core/src/main/scala/dagr/core/execsystem/Resource.scala
@@ -24,18 +24,13 @@
 package dagr.core.execsystem
 
 import oshi.SystemInfo
-import oshi.hardware.platform.mac.MacHardwareAbstractionLayer
 
 /** Manipulates system resources */
 object Resource {
   private val hal = new SystemInfo().getHardware
 
   /** Total number of cores in the system */
-  val systemCores : Cores =
-    if (hal.isInstanceOf[MacHardwareAbstractionLayer])
-      Cores(this.hal.getProcessor.getPhysicalProcessorCount)
-    else
-      Cores(this.hal.getProcessor.getLogicalProcessorCount)
+  val systemCores: Cores = Cores(this.hal.getProcessor.getLogicalProcessorCount)
 
   /** The total amount of memory in the system. */
   val systemMemory: Memory = new Memory(this.hal.getMemory.getTotal)


### PR DESCRIPTION
I have an 8-core MacOS with hyperthreading (16 virtual cores total).

I'd like to tell my tasks to use them all!

Running `ExamplePipeline` before this PR:

```
[2021/01/23 22:40:21 | TaskManager | Info] Executing with 8.0 cores and 24g system memory.
```

And after:

```
[2021/01/23 22:45:31 | TaskManager | Info] Executing with 16.0 cores and 24g system memory.
```

Closes #370.