### PR TITLE
Update travis to use bionic distribution, openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 sudo: required
-dist: trusty
+dist: bionic
 language: scala
 scala:
 - 2.12.2
 jdk:
-- oraclejdk8
+- openjdk8
 script:
 - sbt +clean coverage +test && sbt coverageReport coverageAggregate
 - find $HOME/.sbt -name "*.lock" | xargs rm


### PR DESCRIPTION
Previous builds failed on `pip install` step. The error said to update the python version.

To do that I updated the distribution to `bionic`. That caused an error with installing `oraclejdk8`.

To fix that I changed to `openjdk8`: https://travis-ci.community/t/install-of-oracle-jdk8-is-failing/4365/3