### PR TITLE
Jc allow memory override eib

### DIFF
--- a/core/src/main/scala/dagr/core/tasksystem/Retry.scala
+++ b/core/src/main/scala/dagr/core/tasksystem/Retry.scala
@@ -24,11 +24,11 @@
 
 package dagr.core.tasksystem
 
-import java.nio.file.Files
-
+import com.fulcrumgenomics.commons.io.Io
 import com.fulcrumgenomics.commons.util.LazyLogging
 import dagr.core.execsystem._
-import com.fulcrumgenomics.commons.io.Io
+
+import java.nio.file.Files
 
 /** A trait to facilitate retry a task when it has failed. */
 trait Retry {
@@ -44,7 +44,10 @@ trait Retry {
 /**
   * A trait to facilitate retrying a task with more memory.
   */
-trait MemoryRetry extends Retry with FixedResources {
+trait MemoryRetry extends Retry with FixedResources with LazyLogging {
+  /** returns the maximum number iterations to retry. */
+  def maxNumIterations: Int = 10
+
   /** Given the current memory, returns the next memory to retry this task with, or None, if the task
     * should not be retried.
     */
@@ -64,7 +67,9 @@ trait MemoryRetry extends Retry with FixedResources {
     */
   override final def retry(systemResources: SystemResources, taskInfo: TaskExecutionInfo): Boolean = {
     if (taskInfo.resources.memory != this.resources.memory) throw new IllegalStateException("Scheduled memory does not equal current memory")
-    if (ranOutOfMemory(taskInfo)) {
+    logger.debug("maxNumIterations=" + maxNumIterations + " taskInfo.attemptIndex=" + taskInfo.attemptIndex)
+
+    if (ranOutOfMemory(taskInfo) && taskInfo.attemptIndex <= maxNumIterations) {
       val maximumMemory = if (useSystemMemory) systemResources.systemMemory else systemResources.jvmMemory
       nextMemory(this.resources.memory)
         .filter { _ <= maximumMemory }

--- a/core/src/main/scala/dagr/core/tasksystem/Retry.scala
+++ b/core/src/main/scala/dagr/core/tasksystem/Retry.scala
@@ -24,11 +24,11 @@
 
 package dagr.core.tasksystem
 
-import com.fulcrumgenomics.commons.io.Io
+import java.nio.file.Files
+
 import com.fulcrumgenomics.commons.util.LazyLogging
 import dagr.core.execsystem._
-
-import java.nio.file.Files
+import com.fulcrumgenomics.commons.io.Io
 
 /** A trait to facilitate retry a task when it has failed. */
 trait Retry {
@@ -44,10 +44,7 @@ trait Retry {
 /**
   * A trait to facilitate retrying a task with more memory.
   */
-trait MemoryRetry extends Retry with FixedResources with LazyLogging {
-  /** returns the maximum number iterations to retry. */
-  def maxNumIterations: Int = 10
-
+trait MemoryRetry extends Retry with FixedResources {
   /** Given the current memory, returns the next memory to retry this task with, or None, if the task
     * should not be retried.
     */
@@ -67,9 +64,7 @@ trait MemoryRetry extends Retry with FixedResources with LazyLogging {
     */
   override final def retry(systemResources: SystemResources, taskInfo: TaskExecutionInfo): Boolean = {
     if (taskInfo.resources.memory != this.resources.memory) throw new IllegalStateException("Scheduled memory does not equal current memory")
-    logger.debug("maxNumIterations=" + maxNumIterations + " taskInfo.attemptIndex=" + taskInfo.attemptIndex)
-
-    if (ranOutOfMemory(taskInfo) && taskInfo.attemptIndex <= maxNumIterations) {
+    if (ranOutOfMemory(taskInfo)) {
       val maximumMemory = if (useSystemMemory) systemResources.systemMemory else systemResources.jvmMemory
       nextMemory(this.resources.memory)
         .filter { _ <= maximumMemory }

--- a/tasks/src/main/scala/dagr/tasks/picard/ExtractIlluminaBarcodes.scala
+++ b/tasks/src/main/scala/dagr/tasks/picard/ExtractIlluminaBarcodes.scala
@@ -26,7 +26,7 @@
 package dagr.tasks.picard
 
 import dagr.core.execsystem.{Cores, Memory, ResourceSet}
-import dagr.core.tasksystem.{LinearMemoryRetry, VariableResources}
+import dagr.core.tasksystem.{MemoryDoublingRetry, VariableResources}
 import dagr.tasks.DagrDef.{DirPath, FilePath, PathPrefix}
 
 import scala.collection.mutable.ListBuffer
@@ -51,13 +51,10 @@ class ExtractIlluminaBarcodes(basecallsDir: DirPath,
                               minThreads: Int = 4,
                               maxThreads: Int = 16,
                               override val prefix: Option[PathPrefix] = None
-                             ) extends PicardTask with PicardMetricsTask with VariableResources with LinearMemoryRetry {
+                             ) extends PicardTask with PicardMetricsTask with VariableResources with MemoryDoublingRetry {
   requires(Cores(minThreads), Memory("4G"))
 
   private val _barcodesDir: DirPath = prefix.map(_.getParent).getOrElse(basecallsDir)
-
-  /** returns the maximum number iterations to retry. */
-  override def maxNumIterations: Int = 3
 
   override def pickResources(resources: ResourceSet): Option[ResourceSet] = {
     resources.subset(


### PR DESCRIPTION
This PR allows the setting of memory used by `ExtractIlluminaBarcodes` by using `this.resources.memory`. Previously `pickResources` as always setting memory to `4G`. 

This sets the default value to `4G`, but if the user sets a larger size by using `.requires()` than the new value with be used.

Additionally, this PR adds a LinearMemoryRetry with a retry count of 3.

Tested with a basic pipeline:
```    
val eib   = new ExtractIlluminaBarcodes(basecallsDir=basecallsDir, lane=1, readStructure="151T8B8B151T", barcodeFile=barcodeFile).requires(Cores(8), Memory("64M"))
    root ==> eib
```

```
[2021/06/22 14:01:53 | DagrCoreMain | Info] Executing dagr from dagr version null as j@work on JRE 1.8.0_292-8u292-b10-0ubuntu1~20.04-b10
[2021/06/22 14:01:53 | TaskManager | Info] 'ExtractIlluminaBarcodes' has been started on attempt #1 with 16.00 cores and 64m memory
[2021/06/22 14:01:54 | TaskManager | Info] 'ExtractIlluminaBarcodes' has failed (execution) on attempt #1 with 16.00 cores and 64m memory
[2021/06/22 14:01:54 | TaskManager | Info] 'ExtractIlluminaBarcodes' has been started on attempt #2 with 16.00 cores and 128m memory
[2021/06/22 14:01:55 | TaskManager | Info] 'ExtractIlluminaBarcodes' has failed (execution) on attempt #2 with 16.00 cores and 128m memory
[2021/06/22 14:01:55 | TaskManager | Info] 'ExtractIlluminaBarcodes' has been started on attempt #3 with 16.00 cores and 256m memory
[2021/06/22 14:02:34 | TaskManager | Info] 'ExtractIlluminaBarcodes' has succeeded on attempt #3 with 16.00 cores and 256m memory
[2021/06/22 14:02:34 | TaskManager | Info] ################################################################################
[2021/06/22 14:02:34 | TaskManager | Info] Completed execution successfully.
[2021/06/22 14:02:34 | DagrCoreMain | Info] dagr completed. Elapsed time: 0.69 minutes.
```
