### PR TITLE
Update output file option in BwaMem task args

### DIFF
--- a/tasks/src/main/scala/dagr/tasks/bwa/BwaMem.scala
+++ b/tasks/src/main/scala/dagr/tasks/bwa/BwaMem.scala
@@ -72,7 +72,7 @@ class BwaMem(fastq: PathToFastq = Io.StdIn,
     basesPerBatch.foreach(n => buffer.append("-K", n))
 
     buffer.append(ref, fastq)
-    out.foreach(f => buffer.append("> " + f))
+    out.foreach(f => buffer.append(">", f))
 
     buffer.toList
   }


### PR DESCRIPTION
I was not able to successfully use the optional output file arg in the `BwaMem` task. All the alignments were printed to stOut and my script looked like this:

```
#/bin/bash
set -o pipefail
set -e
# Your command has been wrapped to facilitate piping to a log file
run () {
  bwa mem hs38DH.fa sample1.unmapped.fq '> sample1.aligned.sam'
}
run &> logs/BwaMem.sample1.76.1.log;
```

Notice the single quotes around the output file args. There is an easy workaround which is to just use the `>` operator on the task rather than the input file option.