### PR TITLE
Bump com.fulcrumgenomics.commons version to 1.2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -123,7 +123,7 @@ lazy val core = Project(id="dagr-core", base=file("core"))
   .settings(description := "Core methods and classes to execute tasks in dagr.")
   .settings(
     libraryDependencies ++= Seq(
-      "com.fulcrumgenomics" %%  "commons"           %  "1.1.0-43c062d-SNAPSHOT",
+      "com.fulcrumgenomics" %%  "commons"           %  "1.2.0",
       "com.fulcrumgenomics" %%  "sopt"              %  "1.0.0",
       "com.github.dblock"   %   "oshi-core"         %  "3.3",
       "org.scala-lang"      %   "scala-reflect"     %  scalaVersion.value,


### PR DESCRIPTION
There seems to be an incompatibility in `PathUtil.sanitizeFileName` when using newer versions of `fgbio` with this version of `dagr` (after https://github.com/fulcrumgenomics/commons/pull/67 added a parameter and https://github.com/fulcrumgenomics/fgbio/pull/702 updated version)