### PR TITLE
Add new options to ClipBam and CallDuplexConsensusReads

### DIFF
--- a/tasks/src/main/scala/dagr/tasks/fgbio/CallDuplexConsensusReads.scala
+++ b/tasks/src/main/scala/dagr/tasks/fgbio/CallDuplexConsensusReads.scala
@@ -33,15 +33,16 @@ import scala.collection.mutable.ListBuffer
 
 class CallDuplexConsensusReads(val in: PathToBam,
                                val out: PathToBam,
-                               val readNamePrefix:      Option[String] = None,
-                               val readGroupId:         Option[String] = None,
-                               val errorRatePreUmi:     Option[Int]    = None,
-                               val errorRatePostUmi:    Option[Int]    = None,
-                               val minInputBaseQuality: Option[Int]    = None,
-                               val minReads:            Seq[Int]       = Seq.empty,
-                               val maxReadsPerStrand:   Option[Int]    = None,
-                               val minThreads: Int                     = 1,
-                               val maxThreads: Int                     = 32
+                               val readNamePrefix:      Option[String]            = None,
+                               val readGroupId:         Option[String]            = None,
+                               val errorRatePreUmi:     Option[Int]               = None,
+                               val errorRatePostUmi:    Option[Int]               = None,
+                               val minInputBaseQuality: Option[Int]               = None,
+                               val minReads:            Seq[Int]                  = Seq.empty,
+                               val maxReadsPerStrand:   Option[Int]               = None,
+                               val minThreads: Int                                = 1,
+                               val maxThreads: Int                                = 32,
+                               val consensusCallOverlappingBases: Option[Boolean] = None
                               ) extends FgBioTask with VariableResources with Pipe[SamOrBam,SamOrBam] {
 
   override def pickResources(resources: ResourceSet): Option[ResourceSet] = {
@@ -60,7 +61,8 @@ class CallDuplexConsensusReads(val in: PathToBam,
       buffer.append("-M")
       buffer.append(minReads:_*)
     }
-    maxReadsPerStrand.foreach   (x => buffer.append("--max-reads-per-strand", x))
+    maxReadsPerStrand.foreach            (x => buffer.append("--max-reads-per-strand", x))
+    consensusCallOverlappingBases.foreach(c => buffer.append("--consensus-call-overlapping-bases", c))
     buffer.append("--threads", resources.cores.toInt)
   }
 }

--- a/tasks/src/main/scala/dagr/tasks/fgbio/ClipBam.scala
+++ b/tasks/src/main/scala/dagr/tasks/fgbio/ClipBam.scala
@@ -40,7 +40,9 @@ class ClipBam(val input: PathToBam,
               val readOneThreePrime: Option[Int] = None,
               val readTwoFivePrime: Option[Int] = None,
               val readTwoThreePrime: Option[Int] = None,
-              val clipOverlappingReads: Option[Boolean] = None
+              val clipOverlappingReads: Option[Boolean] = None,
+              val clipBasesPastMate: Option[Boolean] = None,
+              val sortOrder: Option[String] = None
              ) extends FgBioTask {
 
   override protected def addFgBioArgs(buffer: ListBuffer[Any]): Unit = {
@@ -56,6 +58,8 @@ class ClipBam(val input: PathToBam,
     readTwoFivePrime.foreach  (d => buffer.append("--read-two-five-prime", d))
     readTwoThreePrime.foreach (e => buffer.append("--read-two-three-prime", e))
     clipOverlappingReads.foreach(o => buffer.append("--clip-overlapping-reads", o))
+    clipBasesPastMate.foreach   (c => buffer.append("--clip-bases-past-mate", c))
+    sortOrder.foreach           (s => buffer.append("--sort-order", s))
   }
 }
 


### PR DESCRIPTION
Adds some new options that were recently added to these tools. These new options for two of the tools that I typically use in my workflows, but if there are others that should be added, I can add them here as well.

Sort order uses a String, rather than `SamOrder`, same as `SortSam` task.